### PR TITLE
shit

### DIFF
--- a/src/main/java/com/github/noamm9/mixin/KeyboardMixin.java
+++ b/src/main/java/com/github/noamm9/mixin/KeyboardMixin.java
@@ -16,7 +16,7 @@ public abstract class KeyboardMixin {
     @Inject(method = "keyPress", at = @At("HEAD"), cancellable = true)
     private void onKey(long l, int i, KeyEvent keyEvent, CallbackInfo ci) {
         if (keyEvent.key() == GLFW.GLFW_KEY_UNKNOWN) return;
-        if (EventBus.post(new KeyboardEvent.KeyPressed(keyEvent))) {
+        if (EventBus.post(new KeyboardEvent.KeyPressed(keyEvent, i))) {
             ci.cancel();
         }
     }

--- a/src/main/kotlin/com/github/noamm9/event/impl/KeyboardEvent.kt
+++ b/src/main/kotlin/com/github/noamm9/event/impl/KeyboardEvent.kt
@@ -5,6 +5,6 @@ import net.minecraft.client.input.CharacterEvent
 import net.minecraft.client.input.KeyEvent
 
 abstract class KeyboardEvent() : Event(cancelable = true) {
-    class KeyPressed(val keyEvent: KeyEvent) : KeyboardEvent()
+    class KeyPressed(val keyEvent: KeyEvent, val action: Int) : KeyboardEvent()
     class CharTyped(val charEvent: CharacterEvent) : KeyboardEvent()
 }

--- a/src/main/kotlin/com/github/noamm9/features/impl/dungeon/AbilityKeybinds.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/dungeon/AbilityKeybinds.kt
@@ -22,7 +22,7 @@ object AbilityKeybinds: Feature("Allows you do use your dungeon class ult/abilit
     override fun init() {
         register<KeyboardEvent.KeyPressed> {
             if (! LocationUtils.inDungeon || ! DungeonListener.dungeonStarted) return@register
-            if (event.keyEvent.scancode != GLFW.GLFW_PRESS) return@register
+            if (event.action != GLFW.GLFW_PRESS) return@register
             if (mc.screen != null) return@register
 
             if (classUltimate.value && ultKeybind.isPressed()) {

--- a/src/main/kotlin/com/github/noamm9/features/impl/dungeon/Secrets.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/dungeon/Secrets.kt
@@ -80,7 +80,7 @@ object Secrets: Feature() {
         else {
             val max = ActionBarParser.maxSecrets ?: return@hudElement 0f to 0f
             val current = ActionBarParser.secrets ?: return@hudElement 0f to 0f
-            "&7Secrets: ${ColorUtils.colorCodeByPresent(current, max)}$current&7/&a$max"
+            "&7Secrets: ${ColorUtils.colorCodeByPercent(current, max)}$current&7/&a$max"
         }
 
         Render2D.drawString(ctx, line, 0, 0)

--- a/src/main/kotlin/com/github/noamm9/features/impl/dungeon/TerminalTitles.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/dungeon/TerminalTitles.kt
@@ -108,7 +108,7 @@ object TerminalTitles: Feature("Reformats the Terminal titles on P3.") {
     }
 
     private fun handleTitle(name: String, type: String, min: Int, max: Int): String {
-        val color = ColorUtils.colorCodeByPresent(min, max)
+        val color = ColorUtils.colorCodeByPercent(min, max)
         if (phaseDone.value && min == max) return "&a&lPhase Done!"
         val brackets = when (bracket.value) {
             0 -> listOf("(", ")")

--- a/src/main/kotlin/com/github/noamm9/features/impl/dungeon/map/MapRenderer.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/dungeon/map/MapRenderer.kt
@@ -3,7 +3,7 @@ package com.github.noamm9.features.impl.dungeon.map
 import com.github.noamm9.NoammAddons.MOD_ID
 import com.github.noamm9.NoammAddons.mc
 import com.github.noamm9.ui.hud.HudElement
-import com.github.noamm9.utils.ColorUtils.colorCodeByPresent
+import com.github.noamm9.utils.ColorUtils.colorCodeByPercent
 import com.github.noamm9.utils.ColorUtils.colorizeScore
 import com.github.noamm9.utils.MathUtils
 import com.github.noamm9.utils.dungeons.DungeonListener
@@ -63,9 +63,9 @@ object MapRenderer: HudElement() {
         if (! MapConfig.dungeonMapCheater.value && ! DungeonListener.dungeonStarted) return
 
         val secretsStr = "&6Secrets: &b${ScoreCalculation.foundSecrets}&f/&e${DungeonInfo.secretCount}"
-        val cryptsStr = colorCodeByPresent(ScoreCalculation.cryptsCount, 5) + "Crypts: ${ScoreCalculation.cryptsCount}"
+        val cryptsStr = colorCodeByPercent(ScoreCalculation.cryptsCount, 6) + "Crypts: ${ScoreCalculation.cryptsCount}"
         val scoreStr = "&eScore: ${colorizeScore(ScoreCalculation.score)}&r"
-        val deathsStr = "&cDeaths: ${colorCodeByPresent(ScoreCalculation.deathCount, 4, true)}${ScoreCalculation.deathCount}&r"
+        val deathsStr = "&cDeaths: ${colorCodeByPercent(ScoreCalculation.deathCount, 4, true)}${ScoreCalculation.deathCount}&r"
         val mimicStr = "&cM: ${if (ScoreCalculation.mimicKilled) "&a&l✔&r" else "&c&l✖&r"}"
         val princeStr = "&eP: ${if (ScoreCalculation.princeKilled) "&a&l✔&r" else "&c&l✖&r"}"
 

--- a/src/main/kotlin/com/github/noamm9/features/impl/dungeon/solvers/LividSolver.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/dungeon/solvers/LividSolver.kt
@@ -75,7 +75,7 @@ object LividSolver: Feature() {
 
             if (tracer.value) Render3D.renderTracer(event.ctx, livid.renderVec.add(y = 0.9), tracerColor.value)
             if (showHp.value) Render3D.renderString(
-                ColorUtils.colorCodeByPresent(livid.health, livid.maxHealth) + NumbersUtils.format(livid.health),
+                ColorUtils.colorCodeByPercent(livid.health, livid.maxHealth) + NumbersUtils.format(livid.health),
                 livid.renderVec.add(y = 3.0), scale = 1.5f
             )
         }

--- a/src/main/kotlin/com/github/noamm9/features/impl/general/ProtectItem.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/general/ProtectItem.kt
@@ -4,7 +4,6 @@ import com.github.noamm9.config.PogObject
 import com.github.noamm9.event.impl.ContainerEvent
 import com.github.noamm9.event.impl.KeyboardEvent
 import com.github.noamm9.features.Feature
-import com.github.noamm9.mixin.IKeyMapping
 import com.github.noamm9.ui.clickgui.components.getValue
 import com.github.noamm9.ui.clickgui.components.impl.KeybindSetting
 import com.github.noamm9.ui.clickgui.components.impl.ToggleSetting

--- a/src/main/kotlin/com/github/noamm9/features/impl/general/ProtectItem.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/general/ProtectItem.kt
@@ -6,8 +6,11 @@ import com.github.noamm9.event.impl.KeyboardEvent
 import com.github.noamm9.features.Feature
 import com.github.noamm9.mixin.IKeyMapping
 import com.github.noamm9.ui.clickgui.components.getValue
+import com.github.noamm9.ui.clickgui.components.impl.KeybindSetting
 import com.github.noamm9.ui.clickgui.components.impl.ToggleSetting
 import com.github.noamm9.ui.clickgui.components.provideDelegate
+import com.github.noamm9.ui.clickgui.components.section
+import com.github.noamm9.ui.clickgui.components.withDescription
 import com.github.noamm9.ui.notification.NotificationManager
 import com.github.noamm9.utils.ChatUtils
 import com.github.noamm9.utils.ChatUtils.formattedText
@@ -17,6 +20,7 @@ import com.github.noamm9.utils.items.ItemUtils.itemUUID
 import com.github.noamm9.utils.items.ItemUtils.lore
 import com.github.noamm9.utils.items.ItemUtils.skyblockId
 import com.github.noamm9.utils.location.LocationUtils
+import com.github.noamm9.utils.render.Render2D
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandManager
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback
 import net.minecraft.network.chat.Component
@@ -25,12 +29,14 @@ import net.minecraft.world.item.ItemStack
 import net.minecraft.world.item.Items
 import org.lwjgl.glfw.GLFW
 
-object ProtectItem: Feature("Prevents dropping or selling important items. /protectitem") {
+object ProtectItem: Feature("Prevents dropping or selling important items via /protectitem or the keybind.") {
     private val data = PogObject("item_protection", mutableMapOf<String, List<String>>(
         "uuids" to listOf(),
         "ids" to listOf()
     ))
 
+    private val protectBind by KeybindSetting("Protect Key", GLFW.GLFW_KEY_L).section("Keybind").withDescription("Press while hovering an item in an inventory to protect/unprotect it via UUID.")
+    private val showProtected by ToggleSetting("Show Protected Items").withDescription("Shows protected items in the menu with a small icon indicator.")
     private val protectUUID by ToggleSetting("Protect UUID", true)
     private val protectID by ToggleSetting("Protect Skyblock ID", true)
     private val protectStarred by ToggleSetting("Protect Starred", true)
@@ -58,15 +64,21 @@ object ProtectItem: Feature("Prevents dropping or selling important items. /prot
                     event.isCanceled = true
                 }
             }
+
+            if (protectBind.isDown()) {
+                if (stack.itemUUID.isNotBlank()) toggle(stack.itemUUID, "uuids", stack.hoverName.formattedText)
+                else if (stack.skyblockId.isNotBlank()) toggle(stack.skyblockId, "ids", stack.hoverName.formattedText)
+                else NotificationManager.push("Error", "Item has no protectable ID/UUID.")
+                event.isCanceled = true
+            }
         }
 
         register<KeyboardEvent.KeyPressed> {
             if (! enabled || mc.screen != null) return@register
             if (LocationUtils.inDungeon) return@register
 
-            val dropKey = (mc.options.keyDrop as? IKeyMapping)?.key?.value ?: - 1
-            if (event.keyEvent.key != dropKey || event.keyEvent.scancode != GLFW.GLFW_PRESS) return@register
-
+            val dropKey = mc.options.keyDrop.matches(event.keyEvent)
+            if (!dropKey || event.action != GLFW.GLFW_PRESS) return@register
             val heldItem = mc.player?.inventory?.selectedItem ?: return@register
             if (getProtectType(heldItem) != ProtectType.None) {
                 NotificationManager.push("Action Blocked", "This item is protected!", 1500L)
@@ -95,6 +107,16 @@ object ProtectItem: Feature("Prevents dropping or selling important items. /prot
 
                 1
             })
+        }
+
+        register<ContainerEvent.Render.Slot.Post> {
+            if (!showProtected.value) return@register
+            val stack = event.slot.item.takeUnless { it.isEmpty } ?: return@register
+            if (getProtectType(stack) != ProtectType.None){
+                val x = event.slot.x + 1
+                val y = event.slot.y + 1
+                Render2D.drawString(event.context, "§aP", x, y, scale = 0.75, shadow = true)
+            }
         }
     }
 

--- a/src/main/kotlin/com/github/noamm9/features/impl/misc/BlockOverlay.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/misc/BlockOverlay.kt
@@ -12,8 +12,6 @@ import com.github.noamm9.ui.clickgui.components.provideDelegate
 import com.github.noamm9.utils.ColorUtils.withAlpha
 import com.github.noamm9.utils.Utils
 import com.github.noamm9.utils.Utils.equalsOneOf
-import com.github.noamm9.utils.items.ItemUtils.skyblockId
-import com.github.noamm9.utils.location.LocationUtils
 import com.github.noamm9.utils.render.Render3D
 import com.github.noamm9.utils.render.RenderContext
 import net.fabricmc.fabric.api.client.rendering.v1.world.WorldRenderContext

--- a/src/main/kotlin/com/github/noamm9/features/impl/misc/BlockOverlay.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/misc/BlockOverlay.kt
@@ -14,9 +14,7 @@ import com.github.noamm9.utils.Utils
 import com.github.noamm9.utils.Utils.equalsOneOf
 import com.github.noamm9.utils.render.Render3D
 import com.github.noamm9.utils.render.RenderContext
-import net.fabricmc.fabric.api.client.rendering.v1.world.WorldRenderContext
 import net.fabricmc.fabric.api.client.rendering.v1.world.WorldRenderEvents
-import net.minecraft.client.renderer.state.BlockOutlineRenderState
 
 object BlockOverlay: Feature() {
     private val mode by DropdownSetting("Mode", 2, listOf("Outline", "Fill", "Filled Outline"))
@@ -24,37 +22,35 @@ object BlockOverlay: Feature() {
     private val outlineColor by ColorSetting("Outline Color", Utils.favoriteColor, false).hideIf { mode.value == 1 }
     private val lineWidth by SliderSetting("Line Width", 2.5, 1, 10, 0.1).hideIf { mode.value == 1 }
     private val phase by ToggleSetting("Phase")
-    private val hideDuringEtherwarp by ToggleSetting("Hide while using Etherwarp")
+    private val hideDuringEtherwarp by ToggleSetting("Hide with Etherwarp")
 
     override fun init() {
         WorldRenderEvents.BEFORE_BLOCK_OUTLINE.register { context, blockOutlineContext ->
             if (! enabled) return@register true
-            render(context, blockOutlineContext)
+            if (mc.options.hideGui) return@register true
+            if (hideDuringEtherwarp.value && shouldHide()) return@register false
+
+            Render3D.renderBlock(
+                RenderContext.fromContext(context),
+                blockOutlineContext.pos,
+                outlineColor.value,
+                fillColor.value,
+                mode.value.equalsOneOf(0, 2),
+                mode.value.equalsOneOf(1, 2),
+                phase = phase.value,
+                lineWidth.value
+            )
+
             false
         }
     }
 
-    private fun isEtherwarpOverlayLikelyActive(): Boolean {
+    private fun shouldHide(): Boolean {
+        if (! hideDuringEtherwarp.value) return false
         val player = mc.player ?: return false
-        if (!player.isCrouching) return false
+        if (! player.isCrouching) return false
 
         val held = player.mainHandItem.takeUnless { it.isEmpty } ?: return false
         return EtherwarpHelper.getEtherwarpDistance(held) != null
-    }
-
-    fun render(ctx: WorldRenderContext, blockCtx: BlockOutlineRenderState) {
-        if (mc.options.hideGui) return
-        if (hideDuringEtherwarp.value && isEtherwarpOverlayLikelyActive()) return
-
-        Render3D.renderBlock(
-            RenderContext.fromContext(ctx),
-            blockCtx.pos,
-            outlineColor.value,
-            fillColor.value,
-            mode.value.equalsOneOf(0, 2),
-            mode.value.equalsOneOf(1, 2),
-            phase = phase.value,
-            lineWidth.value
-        )
     }
 }

--- a/src/main/kotlin/com/github/noamm9/features/impl/misc/BlockOverlay.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/misc/BlockOverlay.kt
@@ -1,6 +1,7 @@
 package com.github.noamm9.features.impl.misc
 
 import com.github.noamm9.features.Feature
+import com.github.noamm9.features.impl.general.teleport.EtherwarpHelper
 import com.github.noamm9.ui.clickgui.components.getValue
 import com.github.noamm9.ui.clickgui.components.hideIf
 import com.github.noamm9.ui.clickgui.components.impl.ColorSetting
@@ -11,6 +12,8 @@ import com.github.noamm9.ui.clickgui.components.provideDelegate
 import com.github.noamm9.utils.ColorUtils.withAlpha
 import com.github.noamm9.utils.Utils
 import com.github.noamm9.utils.Utils.equalsOneOf
+import com.github.noamm9.utils.items.ItemUtils.skyblockId
+import com.github.noamm9.utils.location.LocationUtils
 import com.github.noamm9.utils.render.Render3D
 import com.github.noamm9.utils.render.RenderContext
 import net.fabricmc.fabric.api.client.rendering.v1.world.WorldRenderContext
@@ -23,6 +26,7 @@ object BlockOverlay: Feature() {
     private val outlineColor by ColorSetting("Outline Color", Utils.favoriteColor, false).hideIf { mode.value == 1 }
     private val lineWidth by SliderSetting("Line Width", 2.5, 1, 10, 0.1).hideIf { mode.value == 1 }
     private val phase by ToggleSetting("Phase")
+    private val hideDuringEtherwarp by ToggleSetting("Hide while using Etherwarp")
 
     override fun init() {
         WorldRenderEvents.BEFORE_BLOCK_OUTLINE.register { context, blockOutlineContext ->
@@ -32,8 +36,17 @@ object BlockOverlay: Feature() {
         }
     }
 
+    private fun isEtherwarpOverlayLikelyActive(): Boolean {
+        val player = mc.player ?: return false
+        if (!player.isCrouching) return false
+
+        val held = player.mainHandItem.takeUnless { it.isEmpty } ?: return false
+        return EtherwarpHelper.getEtherwarpDistance(held) != null
+    }
+
     fun render(ctx: WorldRenderContext, blockCtx: BlockOutlineRenderState) {
         if (mc.options.hideGui) return
+        if (hideDuringEtherwarp.value && isEtherwarpOverlayLikelyActive()) return
 
         Render3D.renderBlock(
             RenderContext.fromContext(ctx),

--- a/src/main/kotlin/com/github/noamm9/ui/notification/NotificationManager.kt
+++ b/src/main/kotlin/com/github/noamm9/ui/notification/NotificationManager.kt
@@ -12,7 +12,8 @@ object NotificationManager {
     private val notifications = CopyOnWriteArrayList<Notification>()
     private var lastFrameTime = System.currentTimeMillis()
 
-    fun push(title: String, message: String, duration: Long = 5000L) {
+    fun push(title: String, message: String, duration: Long = 3000L) {
+        if (notifications.any { it.title == title && it.message == message && it.duration == duration }) return
         notifications.add(Notification(title, message, duration))
     }
 

--- a/src/main/kotlin/com/github/noamm9/utils/ColorUtils.kt
+++ b/src/main/kotlin/com/github/noamm9/utils/ColorUtils.kt
@@ -19,7 +19,7 @@ object ColorUtils {
         }
     }
 
-    fun colorCodeByPresent(value: Number, maxValue: Number, reversed: Boolean = false): String {
+    fun colorCodeByPercent(value: Number, maxValue: Number, reversed: Boolean = false): String {
         val max = maxValue.toFloat().coerceAtLeast(1f)
         val current = value.toFloat().coerceIn(0f, max)
 


### PR DESCRIPTION
fixed keyboard event not keeping track of action type
added option in block overlay to disable itself when using etherwarp (holding it, crouching)
fixed map extra info showing crypts as green when 4/5
added keybind (hold keybind then click) for protectitems via uuid
added option to show which items are protected in inventory