### PR TITLE
fix: KeyPress event triggering on release

### DIFF
--- a/src/main/java/com/github/noamm9/mixin/KeyboardMixin.java
+++ b/src/main/java/com/github/noamm9/mixin/KeyboardMixin.java
@@ -16,6 +16,7 @@ public abstract class KeyboardMixin {
     @Inject(method = "keyPress", at = @At("HEAD"), cancellable = true)
     private void onKey(long l, int i, KeyEvent keyEvent, CallbackInfo ci) {
         if (keyEvent.key() == GLFW.GLFW_KEY_UNKNOWN) return;
+        if (i == GLFW.GLFW_RELEASE) return;
         if (EventBus.post(new KeyboardEvent.KeyPressed(keyEvent, i))) {
             ci.cancel();
         }


### PR DESCRIPTION
This PR ensures that GLFW_RELEASE actions are ignored in the Keyboard#keyPress injection.

### Changes:

- Added an early return:
- if (i == GLFW.GLFW_RELEASE) return;
- Prevents KeyboardEvent.KeyPressed from firing on key release.

### Reasoning:

- keyPress receives both GLFW_PRESS and GLFW_RELEASE.
- Without filtering, release actions could incorrectly trigger KeyPressed logic.
- This change guarantees that:
- Only actual key presses dispatch KeyPressed
- Release events do not produce unintended behavior
- Keyboard input handling remains consistent and predictable

### Impact:

- No breaking changes
- No API modifications
- Improves correctness of key event dispatching

(totally didnt make ai generate this message)