### PR TITLE
Support decimal compact numbers in expression parsing (parseCompactNumberDouble)

### DIFF
--- a/src/main/kotlin/com/github/noamm9/features/impl/misc/InventorySearch.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/misc/InventorySearch.kt
@@ -142,7 +142,7 @@ object InventorySearch: Feature("Lets you search in inventory and support math")
         val stack = ArrayDeque<String>()
 
         for (token in tokens) {
-            val numCheck = NumbersUtils.parseCompactNumber(token)?.toDouble()
+            val numCheck = NumbersUtils.parseCompactNumberDouble(token)?.toDouble()
             when {
                 numCheck != null -> output.add(token)
 
@@ -172,7 +172,7 @@ object InventorySearch: Feature("Lets you search in inventory and support math")
         val evalStack = ArrayDeque<Double>()
 
         for (token in output) {
-            val num = NumbersUtils.parseCompactNumber(token)?.toDouble()
+            val num = NumbersUtils.parseCompactNumberDouble(token)?.toDouble()
 
             if (num != null) evalStack.addFirst(num)
             else if (token in operators) {

--- a/src/main/kotlin/com/github/noamm9/utils/NumbersUtils.kt
+++ b/src/main/kotlin/com/github/noamm9/utils/NumbersUtils.kt
@@ -218,4 +218,26 @@ object NumbersUtils {
         val number = cleanValue.substring(0, cleanValue.length - 1).toDoubleOrNull() ?: return null
         return (number * multiplier).toLong()
     }
+
+    fun parseCompactNumberDouble(value: String): Double? {
+        if (value.isBlank()) return null
+        value.toDoubleOrNull()?.let { return it }
+
+        val cleanValue = value.lowercase().replace(",", "")
+        val lastChar = cleanValue.lastOrNull() ?: return null
+
+        if (! lastChar.isLetter()) return null
+
+        val multiplier: Long = when (lastChar) {
+            'k' -> 1_000L
+            'm' -> 1_000_000L
+            'b' -> 1_000_000_000L
+            't' -> 1_000_000_000_000L
+            else -> return null
+        }
+
+        val numberPartString = cleanValue.substring(0, cleanValue.length - 1)
+
+        return (numberPartString.toDouble() * multiplier)
+    }
 }


### PR DESCRIPTION
Fixed doubles not parsing correctly since `parseCompactNumber` would cast to Long