### PR TITLE
refactor: minor code cleanup and deduplication

### DIFF
--- a/src/main/kotlin/com/github/noamm9/commands/CommandManager.kt
+++ b/src/main/kotlin/com/github/noamm9/commands/CommandManager.kt
@@ -29,7 +29,6 @@ object CommandManager {
                 val root = ClientCommandManager.literal(command.name)
                 CommandNodeBuilder(root).apply { with(command) { build() } }
                 dispatcher.register(root)
-                commands.add(command)
                 NoammAddons.logger.debug("Registered command: /${command.name}")
             }
         }

--- a/src/main/kotlin/com/github/noamm9/features/impl/dungeon/AutoRequeue.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/dungeon/AutoRequeue.kt
@@ -11,6 +11,7 @@ import com.github.noamm9.ui.clickgui.components.withDescription
 import com.github.noamm9.utils.ChatUtils
 import com.github.noamm9.utils.PartyUtils
 import com.github.noamm9.utils.ThreadUtils
+import com.github.noamm9.utils.dungeons.DungeonUtils
 import com.github.noamm9.utils.location.LocationUtils
 
 object AutoRequeue: Feature() {
@@ -20,7 +21,7 @@ object AutoRequeue: Feature() {
 
     private const val prefix = "&bAutoRequeue &f>"
     private val masterMode get() = if (LocationUtils.isMasterMode) "MASTER_" else ""
-    private val floor get() = LocationUtils.FLOOR_NAMES[LocationUtils.dungeonFloorNumber ?: 0]
+    private val floor get() = DungeonUtils.FLOOR_NAMES[LocationUtils.dungeonFloorNumber ?: 0]
 
     private fun feedBackMessage(msg: String) {
         if (! feedback.value) return

--- a/src/main/kotlin/com/github/noamm9/features/impl/dungeon/AutoRequeue.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/dungeon/AutoRequeue.kt
@@ -19,13 +19,8 @@ object AutoRequeue: Feature() {
     private val feedback by ToggleSetting("Feedback", true).withDescription("Print feedback messages from auto in chat.")
 
     private const val prefix = "&bAutoRequeue &f>"
-    private val NUMBERS_TO_TEXT = mapOf(
-        0 to "ENTRANCE", 1 to "ONE", 2 to "TWO", 3 to "THREE",
-        4 to "FOUR", 5 to "FIVE", 6 to "SIX", 7 to "SEVEN"
-    )
-
     private val masterMode get() = if (LocationUtils.isMasterMode) "MASTER_" else ""
-    private val floor get() = NUMBERS_TO_TEXT[LocationUtils.dungeonFloorNumber ?: 0]
+    private val floor get() = LocationUtils.FLOOR_NAMES[LocationUtils.dungeonFloorNumber ?: 0]
 
     private fun feedBackMessage(msg: String) {
         if (! feedback.value) return

--- a/src/main/kotlin/com/github/noamm9/features/impl/general/PartyHelper.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/general/PartyHelper.kt
@@ -15,6 +15,7 @@ import com.github.noamm9.utils.NumbersUtils.toFixed
 import com.github.noamm9.utils.PartyUtils
 import com.github.noamm9.utils.PartyUtils.isLeader
 import com.github.noamm9.utils.ServerUtils
+import com.github.noamm9.utils.dungeons.DungeonUtils
 import com.github.noamm9.utils.location.LocationUtils
 import net.minecraft.client.resources.sounds.SimpleSoundInstance
 import net.minecraft.network.chat.ClickEvent
@@ -94,12 +95,12 @@ object PartyHelper: Feature("Party commands and reformatting.") {
         when {
             canRun("!f") && cmd.startsWith("f") -> {
                 val floor = cmd.removePrefix("f").toIntOrNull() ?: args.getOrNull(0)?.toIntOrNull() ?: return
-                if (floor in 0 .. 7) runCommand("joininstance CATACOMBS_FLOOR_${LocationUtils.FLOOR_NAMES[floor]}", true)
+                if (floor in 0 .. 7) runCommand("joininstance CATACOMBS_FLOOR_${DungeonUtils.FLOOR_NAMES[floor]}", true)
             }
 
             canRun("!m") && cmd.startsWith("m") -> {
                 val floor = cmd.removePrefix("m").toIntOrNull() ?: args.getOrNull(0)?.toIntOrNull() ?: return
-                if (floor in 1 .. 7) runCommand("joininstance MASTER_CATACOMBS_FLOOR_${LocationUtils.FLOOR_NAMES[floor]}", true)
+                if (floor in 1 .. 7) runCommand("joininstance MASTER_CATACOMBS_FLOOR_${DungeonUtils.FLOOR_NAMES[floor]}", true)
             }
 
             canRun("!pt") && (cmd == "pt" || cmd == "ptme") -> {

--- a/src/main/kotlin/com/github/noamm9/features/impl/general/PartyHelper.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/general/PartyHelper.kt
@@ -49,11 +49,6 @@ object PartyHelper: Feature("Party commands and reformatting.") {
     private val playerPattern = Regex("(?<rank>(?:\\[.+?] )?)(?<name>\\w+) ?(?<status>.) ?● ?")
     private val partyCommandRegex = Regex("^Party > (?:\\[[^]]+] )?([^:]+): ([!?.\\-@#`/])(.+)$")
 
-    private val NUMBERS_TO_TEXT = mapOf(
-        0 to "ENTRANCE", 1 to "ONE", 2 to "TWO", 3 to "THREE",
-        4 to "FOUR", 5 to "FIVE", 6 to "SIX", 7 to "SEVEN"
-    )
-
     override fun init() {
         register<PacketEvent.Sent> {
             if (! LocationUtils.onHypixel || ! partyAddons.value) return@register
@@ -99,12 +94,12 @@ object PartyHelper: Feature("Party commands and reformatting.") {
         when {
             canRun("!f") && cmd.startsWith("f") -> {
                 val floor = cmd.removePrefix("f").toIntOrNull() ?: args.getOrNull(0)?.toIntOrNull() ?: return
-                if (floor in 0 .. 7) runCommand("joininstance CATACOMBS_FLOOR_${NUMBERS_TO_TEXT[floor]}", true)
+                if (floor in 0 .. 7) runCommand("joininstance CATACOMBS_FLOOR_${LocationUtils.FLOOR_NAMES[floor]}", true)
             }
 
             canRun("!m") && cmd.startsWith("m") -> {
                 val floor = cmd.removePrefix("m").toIntOrNull() ?: args.getOrNull(0)?.toIntOrNull() ?: return
-                if (floor in 1 .. 7) runCommand("joininstance MASTER_CATACOMBS_FLOOR_${NUMBERS_TO_TEXT[floor]}", true)
+                if (floor in 1 .. 7) runCommand("joininstance MASTER_CATACOMBS_FLOOR_${LocationUtils.FLOOR_NAMES[floor]}", true)
             }
 
             canRun("!pt") && (cmd == "pt" || cmd == "ptme") -> {

--- a/src/main/kotlin/com/github/noamm9/features/impl/visual/DamageSplash.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/visual/DamageSplash.kt
@@ -24,6 +24,7 @@ object DamageSplash: Feature("Reformat Skyblock's Damage Indicators.") {
     private val disableinBoss by ToggleSetting("Hide in Boss").withDescription("Hides all damage indicators in dungeon boss room.")
 
     private val damageRegex = Regex("[✧✯]?(\\d{1,3}(?:,\\d{3})*[⚔+✧❤♞☄✷ﬗ✯]*)")
+    private val colors = listOf("§6", "§c", "§e", "§f")
 
     @Suppress("UNCHECKED_CAST")
     override fun init() {
@@ -60,14 +61,12 @@ object DamageSplash: Feature("Reformat Skyblock's Damage Indicators.") {
         }
     }
 
-    private val colorCodes = listOf("§6", "§c", "§e", "§f")
-
     private fun addRandomColorCodes(inputString: String): String {
         val result = StringBuilder()
         var lastColor: String? = null
 
         for (char in inputString) {
-            val availableColors = colorCodes.filter { it != lastColor }
+            val availableColors = colors.filter { it != lastColor }
             val randomColor = availableColors.random()
             result.append(randomColor).append(char).append("§r")
             lastColor = randomColor

--- a/src/main/kotlin/com/github/noamm9/features/impl/visual/DamageSplash.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/visual/DamageSplash.kt
@@ -60,8 +60,9 @@ object DamageSplash: Feature("Reformat Skyblock's Damage Indicators.") {
         }
     }
 
+    private val colorCodes = listOf("§6", "§c", "§e", "§f")
+
     private fun addRandomColorCodes(inputString: String): String {
-        val colorCodes = listOf("§6", "§c", "§e", "§f")
         val result = StringBuilder()
         var lastColor: String? = null
 

--- a/src/main/kotlin/com/github/noamm9/utils/dungeons/DungeonUtils.kt
+++ b/src/main/kotlin/com/github/noamm9/utils/dungeons/DungeonUtils.kt
@@ -11,6 +11,7 @@ import net.minecraft.world.level.block.SkullBlock
 import net.minecraft.world.level.block.entity.SkullBlockEntity
 
 object DungeonUtils {
+    val FLOOR_NAMES = listOf("ENTRANCE", "ONE", "TWO", "THREE", "FOUR", "FIVE", "SIX", "SEVEN")
     const val WITHER_ESSENCE_ID = "e0f3e929-869e-3dca-9504-54c666ee6f23"
     const val REDSTONE_KEY_ID = "fed95410-aba1-39df-9b95-1d4f361eb66e"
 

--- a/src/main/kotlin/com/github/noamm9/utils/location/LocationUtils.kt
+++ b/src/main/kotlin/com/github/noamm9/utils/location/LocationUtils.kt
@@ -35,11 +35,6 @@ object LocationUtils {
     @JvmField
     var dungeonFloor: String? = null
 
-    val FLOOR_NAMES = mapOf(
-        0 to "ENTRANCE", 1 to "ONE", 2 to "TWO", 3 to "THREE",
-        4 to "FOUR", 5 to "FIVE", 6 to "SIX", 7 to "SEVEN"
-    )
-
     @JvmField
     var dungeonFloorNumber: Int? = null
 

--- a/src/main/kotlin/com/github/noamm9/utils/location/LocationUtils.kt
+++ b/src/main/kotlin/com/github/noamm9/utils/location/LocationUtils.kt
@@ -35,6 +35,11 @@ object LocationUtils {
     @JvmField
     var dungeonFloor: String? = null
 
+    val FLOOR_NAMES = mapOf(
+        0 to "ENTRANCE", 1 to "ONE", 2 to "TWO", 3 to "THREE",
+        4 to "FOUR", 5 to "FIVE", 6 to "SIX", 7 to "SEVEN"
+    )
+
     @JvmField
     var dungeonFloorNumber: Int? = null
 

--- a/src/main/kotlin/com/github/noamm9/utils/network/WebUtils.kt
+++ b/src/main/kotlin/com/github/noamm9/utils/network/WebUtils.kt
@@ -17,6 +17,7 @@ object WebUtils {
     private const val PRIVATE_USER_AGENT =
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
     private const val TIMEOUT = 10_000
+    private val SUCCESS_RANGE = 200..299
 
     private val threadCounter = AtomicInteger(1)
     val networkDispatcher = Executors.newFixedThreadPool(5) {
@@ -64,7 +65,7 @@ object WebUtils {
     suspend fun getString(url: String) = withContext(networkDispatcher) {
         runCatching {
             val res = get(url).getOrThrow()
-            if (res.code !in 200..299) throw IllegalStateException("HTTP ${res.code}: ${res.data}")
+            if (res.code !in SUCCESS_RANGE) throw IllegalStateException("HTTP ${res.code}: ${res.data}")
             res.data
         }
     }
@@ -85,9 +86,9 @@ object WebUtils {
             connection.requestMethod = "GET"
 
             val code = connection.responseCode
-            val stream = if (code in 200..299) connection.inputStream else connection.errorStream
+            val stream = if (code in SUCCESS_RANGE) connection.inputStream else connection.errorStream
 
-            if (code !in 200..299) throw IllegalStateException("HTTP $code")
+            if (code !in SUCCESS_RANGE) throw IllegalStateException("HTTP $code")
 
             stream.use { it.readBytes() }
         }
@@ -95,7 +96,7 @@ object WebUtils {
 
     private fun handleResponse(connection: HttpURLConnection): HttpResponse {
         val code = connection.responseCode
-        val stream = if (code in 200..299) connection.inputStream
+        val stream = if (code in SUCCESS_RANGE) connection.inputStream
         else connection.errorStream ?: connection.inputStream
         val data = stream.bufferedReader().use(BufferedReader::readText)
         val headers = connection.headerFields


### PR DESCRIPTION
## Summary
- Extract `SUCCESS_RANGE` constant in `WebUtils` (avoids repeating `200..299` 4 times)
- Extract `colorCodes` list as class-level constant in `DamageSplash` (avoid re-creating list on every call)
- Remove redundant `commands.add(command)` in `CommandManager.registerAll()` (command already in set during iteration)
- Deduplicate `NUMBERS_TO_TEXT` map from `AutoRequeue` and `PartyHelper` into `LocationUtils.FLOOR_NAMES`