### PR TITLE
fix: ActionBarParser mana regex + Config null safety

### DIFF
--- a/src/main/kotlin/com/github/noamm9/config/Config.kt
+++ b/src/main/kotlin/com/github/noamm9/config/Config.kt
@@ -21,74 +21,70 @@ object Config {
         }
     }
 
-    @Suppress("DEPRECATION")
-    fun load() {
-        runCatching {
-            val fileContent = configFile.bufferedReader().use { it.readText() }.takeUnless { it.isEmpty() } ?: return
-            val jsonObject = JsonParser.parseString(fileContent).asJsonObject ?: return
+    fun load() = runCatching {
+        val fileContent = configFile.bufferedReader().use { it.readText() }.takeUnless { it.isEmpty() } ?: return@runCatching
+        val jsonObject = JsonParser.parseString(fileContent).asJsonObject ?: return@runCatching
 
-            for (featureElement in jsonObject.getAsJsonArray("config") ?: return) {
-                val featureObj = featureElement.asJsonObject
-                val feature = FeatureManager.getFeatureByName(featureObj.get("name")?.asString ?: continue) ?: continue
-                if (featureObj.get("enabled")?.asBoolean != feature.enabled) feature.toggle()
+        for (featureElement in jsonObject.getAsJsonArray("config") ?: return@runCatching) {
+            val featureObj = featureElement.asJsonObject
+            val feature = FeatureManager.getFeatureByName(featureObj.get("name")?.asString ?: continue) ?: continue
+            if (featureObj.get("enabled")?.asBoolean != feature.enabled) feature.toggle()
 
-                featureObj.getAsJsonArray("configSettings")?.forEach { settingElement ->
-                    val settingEntry = settingElement.asJsonObject.entrySet().firstOrNull() ?: return@forEach
-                    val setting = feature.getSettingByName(settingEntry.key)
-                    if (setting is Savable) setting.read(settingEntry.value)
-                }
+            featureObj.getAsJsonArray("configSettings")?.forEach { settingElement ->
+                val settingEntry = settingElement.asJsonObject.entrySet().firstOrNull() ?: return@forEach
+                val setting = feature.getSettingByName(settingEntry.key)
+                if (setting is Savable) setting.read(settingEntry.value)
             }
-
-            jsonObject.getAsJsonArray("hud")?.forEach { hudElement ->
-                val hudObj = hudElement.asJsonObject
-                val hudInstance = FeatureManager.getHudByName(hudObj.get("name")?.asString ?: return@forEach) ?: return@forEach
-
-                hudObj.get("x")?.let { hudInstance.x = it.asFloat }
-                hudObj.get("y")?.let { hudInstance.y = it.asFloat }
-                hudObj.get("scale")?.let { hudInstance.scale = it.asFloat }
-            }
-
-        }.apply {
-            onFailure { logger.error("Error loading config", it) }
-            onSuccess { logger.info("Successfully loaded config") }
         }
+
+        jsonObject.getAsJsonArray("hud")?.forEach { hudElement ->
+            val hudObj = hudElement.asJsonObject
+            val hudInstance = FeatureManager.getHudByName(hudObj.get("name")?.asString ?: return@forEach) ?: return@forEach
+
+            hudObj.get("x")?.let { hudInstance.x = it.asFloat }
+            hudObj.get("y")?.let { hudInstance.y = it.asFloat }
+            hudObj.get("scale")?.let { hudInstance.scale = it.asFloat }
+        }
+
+    }.apply {
+        onFailure { logger.error("Error loading config", it) }
+        onSuccess { logger.info("Successfully loaded config") }
     }
 
-    fun save() {
-        runCatching {
-            val jsonObject = JsonObject().apply {
-                add("config", JsonArray().apply {
-                    for (feature in FeatureManager.features) {
-                        add(JsonObject().apply {
-                            add("name", JsonPrimitive(feature.name))
-                            add("enabled", JsonPrimitive(feature.enabled))
-                            add("configSettings", JsonArray().apply {
-                                for (setting in feature.configSettings) {
-                                    if (setting is Savable) {
-                                        add(JsonObject().apply { add(setting.name, setting.write()) })
-                                    }
-                                }
-                            })
-                        })
-                    }
-                })
-                add("hud", JsonArray().apply {
-                    for (hud in FeatureManager.hudElements) {
-                        add(JsonObject().apply {
-                            add("name", JsonPrimitive(hud.name))
-                            add("x", JsonPrimitive(hud.x))
-                            add("y", JsonPrimitive(hud.y))
-                            add("scale", JsonPrimitive(hud.scale))
-                        })
-                    }
-                })
-            }
 
-            configFile.bufferedWriter().use { it.write(JsonUtils.gsonBuilder.toJson(jsonObject)) }
-        }.apply {
-            onFailure { logger.error("Error on saving config", it) }
-            onSuccess { logger.info("Successfully saved config") }
+    fun save() = runCatching {
+        val jsonObject = JsonObject().apply {
+            add("config", JsonArray().apply {
+                for (feature in FeatureManager.features) {
+                    add(JsonObject().apply {
+                        add("name", JsonPrimitive(feature.name))
+                        add("enabled", JsonPrimitive(feature.enabled))
+                        add("configSettings", JsonArray().apply {
+                            for (setting in feature.configSettings) {
+                                if (setting is Savable) {
+                                    add(JsonObject().apply { add(setting.name, setting.write()) })
+                                }
+                            }
+                        })
+                    })
+                }
+            })
+            add("hud", JsonArray().apply {
+                for (hud in FeatureManager.hudElements) {
+                    add(JsonObject().apply {
+                        add("name", JsonPrimitive(hud.name))
+                        add("x", JsonPrimitive(hud.x))
+                        add("y", JsonPrimitive(hud.y))
+                        add("scale", JsonPrimitive(hud.scale))
+                    })
+                }
+            })
         }
+
+        configFile.bufferedWriter().use { it.write(JsonUtils.gsonBuilder.toJson(jsonObject)) }
+    }.apply {
+        onFailure { logger.error("Error on saving config", it) }
+        onSuccess { logger.info("Successfully saved config") }
     }
 }
 

--- a/src/main/kotlin/com/github/noamm9/config/Config.kt
+++ b/src/main/kotlin/com/github/noamm9/config/Config.kt
@@ -29,8 +29,8 @@ object Config {
 
             for (featureElement in jsonObject.getAsJsonArray("config") ?: return) {
                 val featureObj = featureElement.asJsonObject
-                val feature = FeatureManager.getFeatureByName(featureObj.get("name").asString) ?: continue
-                if (featureObj.get("enabled").asBoolean != feature.enabled) feature.toggle()
+                val feature = FeatureManager.getFeatureByName(featureObj.get("name")?.asString ?: continue) ?: continue
+                if (featureObj.get("enabled")?.asBoolean != feature.enabled) feature.toggle()
 
                 featureObj.getAsJsonArray("configSettings")?.forEach { settingElement ->
                     val settingEntry = settingElement.asJsonObject.entrySet().firstOrNull() ?: return@forEach
@@ -41,7 +41,7 @@ object Config {
 
             jsonObject.getAsJsonArray("hud")?.forEach { hudElement ->
                 val hudObj = hudElement.asJsonObject
-                val hudInstance = FeatureManager.getHudByName(hudObj.get("name").asString) ?: return@forEach
+                val hudInstance = FeatureManager.getHudByName(hudObj.get("name")?.asString ?: return@forEach) ?: return@forEach
 
                 hudObj.get("x")?.let { hudInstance.x = it.asFloat }
                 hudObj.get("y")?.let { hudInstance.y = it.asFloat }

--- a/src/main/kotlin/com/github/noamm9/utils/ActionBarParser.kt
+++ b/src/main/kotlin/com/github/noamm9/utils/ActionBarParser.kt
@@ -24,7 +24,7 @@ object ActionBarParser {
     val OVERFLOW_REGEX = Regex("§3([\\d,]+)ʬ") // §3100ʬ
     val STACKS_REGEX = Regex("§6([0-9]+[ᝐ⁑Ѫ])") // §610⁑
     val SALVATION_REGEX = Regex("T([1-3])!")
-    val MANA_USAGE_REGEX = Regex("§b-[\\d,]+ Mana \\(§6.+?§b\\)|§c§lNOT ENOUGH MANA") // §b-50 Mana (§6Speed Boost§b) , §c§lNOT ENOUGH MANA
+    val MANA_USAGE_REGEX = Regex("§b-([\\d,]+) Mana \\(§6.+?§b\\)|§c§lNOT ENOUGH MANA") // §b-50 Mana (§6Speed Boost§b) , §c§lNOT ENOUGH MANA
     val SECRETS_REGEX = Regex("\\s*§7(\\d+)/(\\d+) Secrets") // §76/10 Secrets§r
 
     val currentSpeed get() = ((mc.player?.abilities?.walkingSpeed ?: 0.1f) * 1000).roundToInt()
@@ -76,7 +76,7 @@ object ActionBarParser {
         }
 
         MANA_USAGE_REGEX.find(input)?.let { match ->
-            currentMana -= match.groupValues.first().remove(",").toIntOrNull() ?: 0
+            currentMana -= match.groupValues[1].remove(",").toIntOrNull() ?: 0
         }
 
         STACKS_REGEX.find(input)?.let { match ->


### PR DESCRIPTION
## Summary
- **ActionBarParser**: `MANA_USAGE_REGEX` was missing a capture group around the number, so `groupValues.first()` returned the full match instead of just the number. `toIntOrNull()` always returned null, meaning mana usage was never subtracted.
- **Config**: Added `?.` null safety on `featureObj.get("name")`, `featureObj.get("enabled")`, and `hudObj.get("name")` to prevent crash on malformed config files.