### PR TITLE
fix: AutoRequeue not working

### DIFF
--- a/src/main/kotlin/com/github/noamm9/config/Config.kt
+++ b/src/main/kotlin/com/github/noamm9/config/Config.kt
@@ -29,8 +29,8 @@ object Config {
 
             for (featureElement in jsonObject.getAsJsonArray("config") ?: return) {
                 val featureObj = featureElement.asJsonObject
-                val feature = FeatureManager.getFeatureByName(featureObj.get("name").asString) ?: continue
-                if (featureObj.get("enabled").asBoolean != feature.enabled) feature.toggle()
+                val feature = FeatureManager.getFeatureByName(featureObj.get("name")?.asString ?: continue) ?: continue
+                if (featureObj.get("enabled")?.asBoolean != feature.enabled) feature.toggle()
 
                 featureObj.getAsJsonArray("configSettings")?.forEach { settingElement ->
                     val settingEntry = settingElement.asJsonObject.entrySet().firstOrNull() ?: return@forEach
@@ -41,7 +41,7 @@ object Config {
 
             jsonObject.getAsJsonArray("hud")?.forEach { hudElement ->
                 val hudObj = hudElement.asJsonObject
-                val hudInstance = FeatureManager.getHudByName(hudObj.get("name").asString) ?: return@forEach
+                val hudInstance = FeatureManager.getHudByName(hudObj.get("name")?.asString ?: return@forEach) ?: return@forEach
 
                 hudObj.get("x")?.let { hudInstance.x = it.asFloat }
                 hudObj.get("y")?.let { hudInstance.y = it.asFloat }

--- a/src/main/kotlin/com/github/noamm9/features/impl/dungeon/AutoRequeue.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/dungeon/AutoRequeue.kt
@@ -37,7 +37,7 @@ object AutoRequeue: Feature() {
             }
 
             ThreadUtils.setTimeout(delay.value * 1000) {
-                if (checkParty.value && PartyUtils.isLeader()) return@setTimeout feedBackMessage("You are not the party leader!")
+                if (checkParty.value && !PartyUtils.isLeader()) return@setTimeout feedBackMessage("You are not the party leader!")
                 ChatUtils.sendMessage("/joininstance ${masterMode}CATACOMBS_FLOOR_${floor}")
             }
         }

--- a/src/main/kotlin/com/github/noamm9/utils/ActionBarParser.kt
+++ b/src/main/kotlin/com/github/noamm9/utils/ActionBarParser.kt
@@ -24,7 +24,7 @@ object ActionBarParser {
     val OVERFLOW_REGEX = Regex("§3([\\d,]+)ʬ") // §3100ʬ
     val STACKS_REGEX = Regex("§6([0-9]+[ᝐ⁑Ѫ])") // §610⁑
     val SALVATION_REGEX = Regex("T([1-3])!")
-    val MANA_USAGE_REGEX = Regex("§b-[\\d,]+ Mana \\(§6.+?§b\\)|§c§lNOT ENOUGH MANA") // §b-50 Mana (§6Speed Boost§b) , §c§lNOT ENOUGH MANA
+    val MANA_USAGE_REGEX = Regex("§b-([\\d,]+) Mana \\(§6.+?§b\\)|§c§lNOT ENOUGH MANA") // §b-50 Mana (§6Speed Boost§b) , §c§lNOT ENOUGH MANA
     val SECRETS_REGEX = Regex("\\s*§7(\\d+)/(\\d+) Secrets") // §76/10 Secrets§r
 
     val currentSpeed get() = ((mc.player?.abilities?.walkingSpeed ?: 0.1f) * 1000).roundToInt()
@@ -76,7 +76,7 @@ object ActionBarParser {
         }
 
         MANA_USAGE_REGEX.find(input)?.let { match ->
-            currentMana -= match.groupValues.first().remove(",").toIntOrNull() ?: 0
+            currentMana -= match.groupValues[1].remove(",").toIntOrNull() ?: 0
         }
 
         STACKS_REGEX.find(input)?.let { match ->

--- a/src/main/kotlin/com/github/noamm9/utils/PartyUtils.kt
+++ b/src/main/kotlin/com/github/noamm9/utils/PartyUtils.kt
@@ -123,9 +123,8 @@ object PartyUtils {
                     val memberMatch = memberFormat.find(segment.trim()) ?: return@forEach
                     addMember(memberMatch.groupValues[2])
                     if (type == "Leader") partyLeader = memberMatch.groupValues[2]
-
-                    return@register
                 }
+                return@register
             }
 
             partyWith.find(message)?.let { match ->


### PR DESCRIPTION
## Summary
Two bugs preventing AutoRequeue from ever working with "Check Party" enabled:

1. **PartyUtils**: `return@register` was inside the `forEach` loop, so only the first member of each "Party Members:" line was parsed. `members.size` never reached 5 → "Not enough players in party!"

2. **AutoRequeue**: `isLeader()` check was inverted — it blocked the leader from requeuing and allowed non-leaders (who can't `/joininstance`) instead.