### PR TITLE
fix: AutoRequeue not working

### DIFF
--- a/src/main/kotlin/com/github/noamm9/features/impl/dungeon/AutoRequeue.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/dungeon/AutoRequeue.kt
@@ -37,7 +37,7 @@ object AutoRequeue: Feature() {
             }
 
             ThreadUtils.setTimeout(delay.value * 1000) {
-                if (checkParty.value && !PartyUtils.isLeader()) return@setTimeout feedBackMessage("You are not the party leader!")
+                if (checkParty.value && ! PartyUtils.isLeader()) return@setTimeout feedBackMessage("You are not the party leader!")
                 ChatUtils.sendMessage("/joininstance ${masterMode}CATACOMBS_FLOOR_${floor}")
             }
         }

--- a/src/main/kotlin/com/github/noamm9/features/impl/dungeon/AutoRequeue.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/dungeon/AutoRequeue.kt
@@ -37,7 +37,7 @@ object AutoRequeue: Feature() {
             }
 
             ThreadUtils.setTimeout(delay.value * 1000) {
-                if (checkParty.value && PartyUtils.isLeader()) return@setTimeout feedBackMessage("You are not the party leader!")
+                if (checkParty.value && !PartyUtils.isLeader()) return@setTimeout feedBackMessage("You are not the party leader!")
                 ChatUtils.sendMessage("/joininstance ${masterMode}CATACOMBS_FLOOR_${floor}")
             }
         }

--- a/src/main/kotlin/com/github/noamm9/utils/DebugHUD.kt
+++ b/src/main/kotlin/com/github/noamm9/utils/DebugHUD.kt
@@ -15,6 +15,7 @@ object DebugHUD {
     fun render(guiGraphics: GuiGraphics) {
         renderDungeonDebug(guiGraphics)
         renderLocationDebug(guiGraphics)
+        renderPartyDebug(guiGraphics)
     }
 
 
@@ -140,5 +141,37 @@ object DebugHUD {
             draw("P3 Section: $sectionName")
         }
 
+    }
+
+    private fun renderPartyDebug(graphics: GuiGraphics) {
+        if (! NoammAddons.debugFlags.contains("party")) return
+        var y = 20
+        val x = 350
+
+        fun draw(text: String, color: Int = 0xFFFFFF) {
+            Render2D.drawString(graphics, text, x, y, color = Color(color))
+            y += 10
+        }
+
+        draw("§d§lPARTY DEBUGGER", 0xFF55FF)
+        draw("In Party: ${if (PartyUtils.isInParty) "§aYES" else "§cNO"}")
+        draw("Is Leader: ${if (PartyUtils.isLeader()) "§aYES" else "§cNO"}")
+
+        val leaderName = PartyUtils.partyLeader
+        val selfName = NoammAddons.mc.player?.gameProfile?.name
+        draw("Party Leader: ${leaderName?.let { "§f$it" } ?: "§7None"}")
+
+        y += 5
+        draw("§b§lMEMBERS (${PartyUtils.members.size})", 0x55FFFF)
+        if (PartyUtils.members.isEmpty()) draw(" §7No members detected...")
+        else PartyUtils.members.forEach { member ->
+            val tags = buildList {
+                if (member == leaderName) add("§6[LEADER]")
+                if (member == selfName) add("§d(YOU)")
+            }.joinToString(" ")
+
+            val tagText = if (tags.isNotEmpty()) " $tags" else ""
+            draw(" §f$member$tagText")
+        }
     }
 }

--- a/src/main/kotlin/com/github/noamm9/utils/PartyUtils.kt
+++ b/src/main/kotlin/com/github/noamm9/utils/PartyUtils.kt
@@ -141,6 +141,8 @@ object PartyUtils {
         }
     }
 
+    fun isLeader(): Boolean = partyLeader == mc.user.name
+
     private fun addMember(playerName: String) {
         if (! isInParty) isInParty = true
         if (playerName !in members) members.add(playerName)
@@ -157,6 +159,4 @@ object PartyUtils {
         partyLeader = null
         isInParty = false
     }
-
-    fun isLeader(): Boolean = partyLeader == mc.player?.gameProfile?.name
 }

--- a/src/main/kotlin/com/github/noamm9/utils/PartyUtils.kt
+++ b/src/main/kotlin/com/github/noamm9/utils/PartyUtils.kt
@@ -123,9 +123,8 @@ object PartyUtils {
                     val memberMatch = memberFormat.find(segment.trim()) ?: return@forEach
                     addMember(memberMatch.groupValues[2])
                     if (type == "Leader") partyLeader = memberMatch.groupValues[2]
-
-                    return@register
                 }
+                return@register
             }
 
             partyWith.find(message)?.let { match ->


### PR DESCRIPTION
## Summary
Two bugs preventing AutoRequeue from ever working with "Check Party" enabled:

1. **PartyUtils**: `return@register` was inside the `forEach` loop, so only the first member of each "Party Members:" line was parsed. `members.size` never reached 5 → "Not enough players in party!"

2. **AutoRequeue**: `isLeader()` check was inverted — it blocked the leader from requeuing and allowed non-leaders (who can't `/joininstance`) instead.