### PR TITLE
feat: add Auto Kick to Party Finder

### DIFF
--- a/src/main/kotlin/com/github/noamm9/TestGround.kt
+++ b/src/main/kotlin/com/github/noamm9/TestGround.kt
@@ -91,7 +91,6 @@ class TestGround {
                 val room = ScanUtils.getRoomFromPos(bat.position()) ?: return@register
                 ThreadUtils.scheduledTask(5) {
                     ChatUtils.modMessage("bat hp: ${bat.maxHealth}. (${room.name})")
-
                 }
             }
         }

--- a/src/main/kotlin/com/github/noamm9/features/impl/dungeon/PartyFinder.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/dungeon/PartyFinder.kt
@@ -1,10 +1,16 @@
 package com.github.noamm9.features.impl.dungeon
 
+import com.github.noamm9.NoammAddons.PREFIX
+import com.github.noamm9.event.impl.ChatMessageEvent
 import com.github.noamm9.event.impl.ContainerEvent
 import com.github.noamm9.event.impl.ContainerFullyOpenedEvent
+import com.github.noamm9.event.impl.WorldChangeEvent
 import com.github.noamm9.features.Feature
 import com.github.noamm9.ui.clickgui.components.*
+import com.github.noamm9.ui.clickgui.components.impl.DropdownSetting
+import com.github.noamm9.ui.clickgui.components.impl.SliderSetting
 import com.github.noamm9.ui.clickgui.components.impl.ToggleSetting
+import com.github.noamm9.utils.ChatUtils
 import com.github.noamm9.utils.ChatUtils.addColor
 import com.github.noamm9.utils.ChatUtils.formattedText
 import com.github.noamm9.utils.ChatUtils.removeFormatting
@@ -14,6 +20,8 @@ import com.github.noamm9.utils.JsonUtils.getObj
 import com.github.noamm9.utils.NumbersUtils
 import com.github.noamm9.utils.NumbersUtils.romanToDecimal
 import com.github.noamm9.utils.NumbersUtils.toFixed
+import com.github.noamm9.utils.PartyUtils
+import com.github.noamm9.utils.ThreadUtils
 import com.github.noamm9.utils.Utils.remove
 import com.github.noamm9.utils.items.ItemUtils.lore
 import com.github.noamm9.utils.network.ApiUtils
@@ -22,6 +30,7 @@ import com.github.noamm9.utils.network.cache.ProfileCache
 import com.github.noamm9.utils.render.Render2D
 import com.github.noamm9.utils.render.Render2D.width
 import kotlinx.coroutines.launch
+import net.minecraft.network.chat.ClickEvent
 import net.minecraft.network.chat.Component
 import net.minecraft.world.item.Items
 import net.minecraft.world.level.block.Blocks
@@ -35,6 +44,17 @@ object PartyFinder: Feature() {
     private val showSecrets by ToggleSetting("Show Secrets", true).withDescription("Shows Total Secrets and Average.").showIf { showTooltipStats.value }
     private val showPB by ToggleSetting("Show PB", true).withDescription("Shows Personal Best for the current floor.").showIf { showTooltipStats.value }
     private val showMissingTooltip by ToggleSetting("Show Missing List", true).withDescription("Shows the list of missing classes at the bottom of the tooltip.")
+
+    private val sendKickLine by ToggleSetting("Send Kick Line", true).withDescription("Shows a clickable kick button in chat when a player joins.").section("Auto Kick")
+    private val autoKick by ToggleSetting("Auto Kick", false).withDescription("Automatically kick players that don't meet requirements.")
+    private val autoKickFloor by DropdownSetting("Floor", 6, listOf("F1", "F2", "F3", "F4", "F5", "F6", "F7")).showIf { autoKick.value }
+    private val masterMode by ToggleSetting("Master Mode", true).showIf { autoKick.value }
+    private val informKicked by ToggleSetting("Inform Kicked", false).withDescription("Send a party chat message before kicking.").showIf { autoKick.value }
+    private val maximumSeconds by SliderSetting("Maximum Seconds", 400, 60, 480, 10, suffix = "s").withDescription("Maximum S+ PB time in seconds.").showIf { autoKick.value }
+    private val minimumSecrets by SliderSetting("Minimum Secrets", 0, 0, 200, 1, suffix = "k").withDescription("Minimum secrets in thousands.").showIf { autoKick.value }
+
+    private val pfJoinRegex = Regex("^Party Finder > (?:\\[[^]]*?])? ?(\\w{1,16}) joined the dungeon group! \\(.*\\)$")
+    private val kickedPlayers = mutableSetOf<String>()
 
     private val partyMembersRegex = Regex("§5 (.+)§f: §e(.+)§b \\(..(\\d+)..\\)")
     private val levelRequiredRegex = Regex("§7Dungeon Level Required: §b(\\d+)")
@@ -154,6 +174,41 @@ object PartyFinder: Feature() {
         }
 
         register<ContainerEvent.Close> { inPartyFinder = false }
+        register<WorldChangeEvent> { kickedPlayers.clear() }
+
+        register<ChatMessageEvent> {
+            val match = pfJoinRegex.find(event.unformattedText) ?: return@register
+            val name = match.groupValues[1]
+
+            if (sendKickLine.value) {
+                ChatUtils.chat(Component.literal("$PREFIX §aClick to kick §e$name").withStyle {
+                    it.withClickEvent(ClickEvent.RunCommand("/party kick $name"))
+                })
+            }
+
+            if (!autoKick.value) return@register
+            if (!PartyUtils.isLeader()) return@register
+
+            if (name in kickedPlayers) {
+                ChatUtils.modMessage("&cAuto-kicking &e$name &c(previously kicked)")
+                ThreadUtils.scheduledTask(6) { ChatUtils.sendCommand("party kick $name") }
+                return@register
+            }
+
+            scope.launch {
+                val reasons = checkPlayer(name)
+                if (reasons.isNotEmpty()) {
+                    kickedPlayers.add(name)
+                    if (informKicked.value) {
+                        ChatUtils.sendCommand("pc Kicked $name: ${reasons.joinToString(", ")}")
+                        ThreadUtils.scheduledTask(6) { ChatUtils.sendCommand("party kick $name") }
+                    } else {
+                        ChatUtils.sendCommand("party kick $name")
+                    }
+                    ChatUtils.modMessage("&cKicked &e$name&c: ${reasons.joinToString(", ")}")
+                }
+            }
+        }
     }
 
     private fun getColor(level: Int) = when {
@@ -168,6 +223,32 @@ object PartyFinder: Feature() {
         level >= 10 -> "§e"
         level >= 5 -> "§f"
         else -> "§7"
+    }
+
+    private suspend fun checkPlayer(name: String): List<String> {
+        val reasons = mutableListOf<String>()
+        val profile = ProfileUtils.getProfile(name).getOrNull() ?: return reasons
+
+        val dungeons = profile.getObj("dungeons") ?: return reasons
+        val floor = autoKickFloor.value + 1
+        val dungeonType = if (masterMode.value) dungeons.getObj("master_catacombs") else dungeons.getObj("catacombs")
+
+        val floorPrefix = if (masterMode.value) "M" else "F"
+        val pb = dungeonType?.getObj("fastest_time_s_plus")?.getInt("$floor")
+        if (pb == null || pb / 1000 > maximumSeconds.value) {
+            val actual = pb?.let { "${it / 1000}s" } ?: "N/A"
+            reasons.add("Did not meet time req for $floorPrefix$floor: $actual/${maximumSeconds.value}s")
+        }
+
+        if (minimumSecrets.value > 0) {
+            val secrets = dungeons.getInt("secrets") ?: 0
+            val minRequired = minimumSecrets.value * 1000
+            if (secrets < minRequired) {
+                reasons.add("Did not meet secret req: ${secrets / 1000}k/${minimumSecrets.value}k")
+            }
+        }
+
+        return reasons
     }
 
     private fun getStats(name: String, floor: Int, type: Char): String {

--- a/src/main/kotlin/com/github/noamm9/features/impl/dungeon/PartyFinder.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/dungeon/PartyFinder.kt
@@ -35,15 +35,14 @@ import java.util.*
 
 object PartyFinder: Feature() {
     private val showLevelReq by ToggleSetting("Show Level Req", true).withDescription("Shows the red level requirement number.").section("Menu")
-    private val showMissingOverlay by ToggleSetting("Show Missing Classes", true).withDescription("Shows missing classes initials on the head.")
+    private val showMissingOverlay by ToggleSetting("Show Missing Classes", true).withDescription("Shows missing classes on the head.")
 
     private val showTooltipStats by ToggleSetting("Show Stats", true).withDescription("Shows player stats (Cata/Secrets/PB) in tooltip.").section("Tooltip")
     private val showSecrets by ToggleSetting("Show Secrets", true).withDescription("Shows Total Secrets and Average.").showIf { showTooltipStats.value }
     private val showPB by ToggleSetting("Show PB", true).withDescription("Shows Personal Best for the current floor.").showIf { showTooltipStats.value }
     private val showMissingTooltip by ToggleSetting("Show Missing List", true).withDescription("Shows the list of missing classes at the bottom of the tooltip.")
 
-    private val sendKickLine by ToggleSetting("Send Kick Line", true).withDescription("Shows a clickable kick button in chat when a player joins.").section("Auto Kick")
-    private val autoKick by ToggleSetting("Auto Kick", false).withDescription("Automatically kick players that don't meet requirements.")
+    private val autoKick by ToggleSetting("Auto Kick", false).withDescription("Automatically kick players that don't meet requirements.").section("Auto Kick")
     private val autoKickFloor by DropdownSetting("Floor", 6, listOf("F1", "F2", "F3", "F4", "F5", "F6", "F7")).showIf { autoKick.value }
     private val masterMode by ToggleSetting("Master Mode", true).showIf { autoKick.value }
     private val informKicked by ToggleSetting("Inform Kicked", false).withDescription("Send a party chat message before kicking.").showIf { autoKick.value }
@@ -176,13 +175,8 @@ object PartyFinder: Feature() {
         register<WorldChangeEvent> { kickedPlayers.clear() }
 
         register<ChatMessageEvent> {
-            val name = joinedRegex.find(event.formattedText)?.destructured?.component1() ?: return@register
-
-            if (sendKickLine.value) ThreadUtils.scheduledTask {
-                ChatUtils.clickableChat("§aClick to kick §e$name", true, command = "/party kick $name")
-            }
-
             if (! autoKick.value || ! PartyUtils.isLeader()) return@register
+            val name = joinedRegex.find(event.formattedText)?.destructured?.component1() ?: return@register
 
             if (name in kickedPlayers) {
                 ChatUtils.modMessage("$prefix &cAuto-kicking &e$name &c(previously kicked)")
@@ -192,14 +186,16 @@ object PartyFinder: Feature() {
 
             scope.launch {
                 val reasons = checkPlayer(name.removeFormatting()).takeUnless { it.isEmpty() } ?: return@launch
-                ChatUtils.modMessage("&cKicking &e$name:&r ${reasons.joinToString(", ")}")
                 kickedPlayers.add(name)
 
                 if (informKicked.value) {
                     ChatUtils.sendCommand("pc Kicking $name: ${reasons.joinToString(", ")}")
                     ThreadUtils.scheduledTask(6) { ChatUtils.sendCommand("party kick $name") }
                 }
-                else ChatUtils.sendCommand("party kick $name")
+                else {
+                    ChatUtils.modMessage("&cKicking &e$name:&r ${reasons.joinToString(", ")}")
+                    ChatUtils.sendCommand("party kick $name")
+                }
             }
         }
     }
@@ -216,7 +212,7 @@ object PartyFinder: Feature() {
         val floorPrefix = if (masterMode.value) "M" else "F"
         val pbReq = formatTime(maximumSeconds.value * 1000)
         val pb = dungeonType?.getObj("fastest_time_s_plus")?.getInt("$floor")?.div(1000)
-        if (pb == null) reasons.add("PB(&c&lNo S+&f/$pbReq)")
+        if (pb == null) reasons.add("PB(No S+/$pbReq)")
         else if (pb / 1000 > maximumSeconds.value) {
             reasons.add("$floorPrefix$floor: PB(${formatTime(pb)}/$pbReq)")
         }

--- a/src/main/kotlin/com/github/noamm9/features/impl/dungeon/PartyFinder.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/dungeon/PartyFinder.kt
@@ -1,6 +1,5 @@
 package com.github.noamm9.features.impl.dungeon
 
-import com.github.noamm9.NoammAddons.PREFIX
 import com.github.noamm9.event.impl.ChatMessageEvent
 import com.github.noamm9.event.impl.ContainerEvent
 import com.github.noamm9.event.impl.ContainerFullyOpenedEvent
@@ -17,12 +16,11 @@ import com.github.noamm9.utils.ChatUtils.removeFormatting
 import com.github.noamm9.utils.JsonUtils.getDouble
 import com.github.noamm9.utils.JsonUtils.getInt
 import com.github.noamm9.utils.JsonUtils.getObj
-import com.github.noamm9.utils.NumbersUtils
 import com.github.noamm9.utils.NumbersUtils.romanToDecimal
 import com.github.noamm9.utils.NumbersUtils.toFixed
 import com.github.noamm9.utils.PartyUtils
 import com.github.noamm9.utils.ThreadUtils
-import com.github.noamm9.utils.Utils.remove
+import com.github.noamm9.utils.Utils.equalsOneOf
 import com.github.noamm9.utils.items.ItemUtils.lore
 import com.github.noamm9.utils.network.ApiUtils
 import com.github.noamm9.utils.network.ProfileUtils
@@ -30,7 +28,6 @@ import com.github.noamm9.utils.network.cache.ProfileCache
 import com.github.noamm9.utils.render.Render2D
 import com.github.noamm9.utils.render.Render2D.width
 import kotlinx.coroutines.launch
-import net.minecraft.network.chat.ClickEvent
 import net.minecraft.network.chat.Component
 import net.minecraft.world.item.Items
 import net.minecraft.world.level.block.Blocks
@@ -53,8 +50,9 @@ object PartyFinder: Feature() {
     private val maximumSeconds by SliderSetting("Maximum Seconds", 400, 60, 480, 10, suffix = "s").withDescription("Maximum S+ PB time in seconds.").showIf { autoKick.value }
     private val minimumSecrets by SliderSetting("Minimum Secrets", 0, 0, 200, 1, suffix = "k").withDescription("Minimum secrets in thousands.").showIf { autoKick.value }
 
-    private val pfJoinRegex = Regex("^Party Finder > (?:\\[[^]]*?])? ?(\\w{1,16}) joined the dungeon group! \\(.*\\)$")
+    private val joinedRegex = Regex("^§dParty Finder §f> (.+?) §ejoined the dungeon group! \\(§b(\\w+) Level (\\d+)§e\\)$")
     private val kickedPlayers = mutableSetOf<String>()
+    private const val prefix = "&9AutoKick &f>"
 
     private val partyMembersRegex = Regex("§5 (.+)§f: §e(.+)§b \\(..(\\d+)..\\)")
     private val levelRequiredRegex = Regex("§7Dungeon Level Required: §b(\\d+)")
@@ -174,59 +172,41 @@ object PartyFinder: Feature() {
         }
 
         register<ContainerEvent.Close> { inPartyFinder = false }
+
         register<WorldChangeEvent> { kickedPlayers.clear() }
 
         register<ChatMessageEvent> {
-            val match = pfJoinRegex.find(event.unformattedText) ?: return@register
-            val name = match.groupValues[1]
+            val name = joinedRegex.find(event.formattedText)?.destructured?.component1() ?: return@register
 
-            if (sendKickLine.value) {
-                ChatUtils.chat(Component.literal("$PREFIX §aClick to kick §e$name").withStyle {
-                    it.withClickEvent(ClickEvent.RunCommand("/party kick $name"))
-                })
+            if (sendKickLine.value) ThreadUtils.scheduledTask {
+                ChatUtils.clickableChat("§aClick to kick §e$name", true, command = "/party kick $name")
             }
 
-            if (!autoKick.value) return@register
-            if (!PartyUtils.isLeader()) return@register
+            if (! autoKick.value || ! PartyUtils.isLeader()) return@register
 
             if (name in kickedPlayers) {
-                ChatUtils.modMessage("&cAuto-kicking &e$name &c(previously kicked)")
+                ChatUtils.modMessage("$prefix &cAuto-kicking &e$name &c(previously kicked)")
                 ThreadUtils.scheduledTask(6) { ChatUtils.sendCommand("party kick $name") }
                 return@register
             }
 
             scope.launch {
-                val reasons = checkPlayer(name)
-                if (reasons.isNotEmpty()) {
-                    kickedPlayers.add(name)
-                    if (informKicked.value) {
-                        ChatUtils.sendCommand("pc Kicked $name: ${reasons.joinToString(", ")}")
-                        ThreadUtils.scheduledTask(6) { ChatUtils.sendCommand("party kick $name") }
-                    } else {
-                        ChatUtils.sendCommand("party kick $name")
-                    }
-                    ChatUtils.modMessage("&cKicked &e$name&c: ${reasons.joinToString(", ")}")
+                val reasons = checkPlayer(name.removeFormatting()).takeUnless { it.isEmpty() } ?: return@launch
+                ChatUtils.modMessage("&cKicking &e$name:&r ${reasons.joinToString(", ")}")
+                kickedPlayers.add(name)
+
+                if (informKicked.value) {
+                    ChatUtils.sendCommand("pc Kicking $name: ${reasons.joinToString(", ")}")
+                    ThreadUtils.scheduledTask(6) { ChatUtils.sendCommand("party kick $name") }
                 }
+                else ChatUtils.sendCommand("party kick $name")
             }
         }
     }
 
-    private fun getColor(level: Int) = when {
-        level >= 50 -> "§c§l"
-        level >= 45 -> "§c"
-        level >= 40 -> "§6"
-        level >= 35 -> "§d"
-        level >= 30 -> "§9"
-        level >= 25 -> "§b"
-        level >= 20 -> "§2"
-        level >= 15 -> "§a"
-        level >= 10 -> "§e"
-        level >= 5 -> "§f"
-        else -> "§7"
-    }
-
     private suspend fun checkPlayer(name: String): List<String> {
         val reasons = mutableListOf<String>()
+        if (name.equalsOneOf("Noamm", mc.user.name)) return reasons
         val profile = ProfileUtils.getProfile(name).getOrNull() ?: return reasons
 
         val dungeons = profile.getObj("dungeons") ?: return reasons
@@ -234,17 +214,17 @@ object PartyFinder: Feature() {
         val dungeonType = if (masterMode.value) dungeons.getObj("master_catacombs") else dungeons.getObj("catacombs")
 
         val floorPrefix = if (masterMode.value) "M" else "F"
-        val pb = dungeonType?.getObj("fastest_time_s_plus")?.getInt("$floor")
-        if (pb == null || pb / 1000 > maximumSeconds.value) {
-            val actual = pb?.let { "${it / 1000}s" } ?: "N/A"
-            reasons.add("Did not meet time req for $floorPrefix$floor: $actual/${maximumSeconds.value}s")
+        val pbReq = formatTime(maximumSeconds.value * 1000)
+        val pb = dungeonType?.getObj("fastest_time_s_plus")?.getInt("$floor")?.div(1000)
+        if (pb == null) reasons.add("PB(&c&lNo S+&f/$pbReq)")
+        else if (pb / 1000 > maximumSeconds.value) {
+            reasons.add("$floorPrefix$floor: PB(${formatTime(pb)}/$pbReq)")
         }
 
         if (minimumSecrets.value > 0) {
             val secrets = dungeons.getInt("secrets") ?: 0
-            val minRequired = minimumSecrets.value * 1000
-            if (secrets < minRequired) {
-                reasons.add("Did not meet secret req: ${secrets / 1000}k/${minimumSecrets.value}k")
+            if (secrets < minimumSecrets.value * 1000) {
+                reasons.add("Secrets(${secrets / 1000}k/${minimumSecrets.value}k)")
             }
         }
 
@@ -297,17 +277,37 @@ object PartyFinder: Feature() {
             if (showPB.value) {
                 val pbObj = if (type == 'F') catacombs else masterCatacombs
                 val pbTime = pbObj?.getObj("fastest_time_s_plus")?.getInt("$floor")
-
-                val pb = pbTime?.let { time ->
-                    val str = NumbersUtils.formatTime(time)
-                    str.split(" ").joinToString(":") {
-                        if (it.length == 2 && it.contains("s")) ("0" + it.remove("s"))
-                        else it.remove("m", "s")
-                    }
-                } ?: "N/A"
-
+                val pb = pbTime?.let(::formatTime) ?: "N/A"
                 append(" §8[§9$pb§8]§r")
             }
         }
+    }
+
+
+    private fun getColor(level: Int) = when {
+        level >= 50 -> "§c§l"
+        level >= 45 -> "§c"
+        level >= 40 -> "§6"
+        level >= 35 -> "§d"
+        level >= 30 -> "§9"
+        level >= 25 -> "§b"
+        level >= 20 -> "§2"
+        level >= 15 -> "§a"
+        level >= 10 -> "§e"
+        level >= 5 -> "§f"
+        else -> "§7"
+    }
+
+    private fun formatTime(milliseconds: Number): String {
+        val totalSecs = milliseconds.toLong() / 1000
+        val h = totalSecs / 3600
+        val m = (totalSecs % 3600) / 60
+        val s = totalSecs % 60
+
+        return buildList {
+            if (h > 0) add(h)
+            if (m > 0) add(m)
+            if (s > 0) add(s)
+        }.joinToString(":")
     }
 }

--- a/src/main/kotlin/com/github/noamm9/ui/clickgui/components/impl/SliderSetting.kt
+++ b/src/main/kotlin/com/github/noamm9/ui/clickgui/components/impl/SliderSetting.kt
@@ -20,7 +20,8 @@ open class SliderSetting<T: Number>(
     value: T,
     val min: T,
     val max: T,
-    val step: T
+    val step: T,
+    val suffix: String = ""
 ): Setting<T>(name, value), Savable {
     private var dragging = false
     private var isTyping = false
@@ -49,7 +50,7 @@ open class SliderSetting<T: Number>(
         Style.drawHoverBar(ctx, x, y, 20f, hoverAnim.value)
         Style.drawNudgedText(ctx, name, x + 8f, y + 2f, hoverAnim.value)
 
-        val valStr = if (isTyping) inputBuffer else stringfy(value)
+        val valStr = if (isTyping) inputBuffer else stringfy(value) + suffix
         val textColor = if (isTyping) Style.accentColor else Color(180, 180, 180)
         Render2D.drawString(ctx, valStr, x + width - valStr.width() - 8f, y + 2f, textColor)
 

--- a/src/main/kotlin/com/github/noamm9/utils/NumbersUtils.kt
+++ b/src/main/kotlin/com/github/noamm9/utils/NumbersUtils.kt
@@ -180,17 +180,6 @@ object NumbersUtils {
         }.joinToString(" ")
     }
 
-    fun formatMilis(milliseconds: Number): String {
-        val totalSeconds = milliseconds.toDouble() / 1000.0
-
-        if (totalSeconds < 60) return totalSeconds.toFixed(3) + " sec"
-        else {
-            val minutes = (totalSeconds / 60).toInt()
-            val remainingSeconds = totalSeconds % 60
-            return "$minutes min ${remainingSeconds.toFixed(3)} seconds"
-        }
-    }
-
     private fun processDecimal(decimal: Int, lastNumber: Int, lastDecimal: Int): Int {
         return if (lastNumber > decimal) lastDecimal - decimal
         else lastDecimal + decimal


### PR DESCRIPTION
## Summary
Adds auto-kick functionality to the existing Party Finder feature.

### New settings (Auto Kick section)
- **Send Kick Line** — clickable `[NA] Click to kick <name>` message in chat when someone joins via PF
- **Auto Kick** — automatically kick players that don't meet requirements
- **Floor** — dropdown F1-F7, which floor to check PB for
- **Master Mode** — toggle between normal and master mode PB check
- **Inform Kicked** — send party chat message explaining kick reason before kicking
- **Maximum Seconds** — S+ PB time threshold (60-480s)
- **Minimum Secrets** — minimum secrets threshold (0-200k)

### Other changes
- **SliderSetting**: added optional `suffix` parameter for displaying units (e.g. `400s`, `24k`)
- Kick cache auto-clears on world change