### PR TITLE
fix: shader-based fullbright to fix yellow circle artifacts

### DIFF
--- a/src/main/java/com/github/noamm9/mixin/MixinGameRenderer.java
+++ b/src/main/java/com/github/noamm9/mixin/MixinGameRenderer.java
@@ -28,13 +28,6 @@ public class MixinGameRenderer {
     @Final
     private Minecraft minecraft;
 
-    @Inject(method = "getNightVisionScale", at = @At("HEAD"), cancellable = true)
-    private static void onGetNightVisionScale(LivingEntity entity, float partialTicks, CallbackInfoReturnable<Float> cir) {
-        if (Camera.INSTANCE.enabled && Camera.getFullBright().getValue()) {
-            cir.setReturnValue(0.0f);
-        }
-    }
-
     @Inject(method = "bobHurt", at = @At("HEAD"), cancellable = true)
     public void onBobHurt(PoseStack poseStack, float f, CallbackInfo ci) {
         if (this.minecraft.options.damageTiltStrength().get() == 0) {

--- a/src/main/java/com/github/noamm9/mixin/MixinGlDevice.java
+++ b/src/main/java/com/github/noamm9/mixin/MixinGlDevice.java
@@ -1,0 +1,56 @@
+package com.github.noamm9.mixin;
+
+import com.github.noamm9.features.impl.misc.Camera;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.mojang.blaze3d.opengl.GlDevice;
+import com.mojang.blaze3d.opengl.GlRenderPipeline;
+import com.mojang.blaze3d.pipeline.RenderPipeline;
+import com.mojang.blaze3d.shaders.ShaderType;
+import net.minecraft.client.renderer.RenderPipelines;
+import net.minecraft.resources.ResourceLocation;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.function.BiFunction;
+
+@Mixin(GlDevice.class)
+public class MixinGlDevice {
+    @Unique private static boolean lastFullBright = false;
+
+    @WrapOperation(
+        method = "compileShader",
+        at = @At(value = "INVOKE", target = "Ljava/util/function/BiFunction;apply(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;")
+    )
+    private Object noammaddons$fullbright(BiFunction<ResourceLocation, ShaderType, String> instance, Object id_, Object type_, Operation<String> original) {
+        if (!Camera.INSTANCE.enabled || !Camera.getFullBright().getValue())
+            return original.call(instance, id_, type_);
+
+        ResourceLocation id = (ResourceLocation) id_;
+        ShaderType type = (ShaderType) type_;
+        if (type != ShaderType.FRAGMENT || !id.equals(RenderPipelines.LIGHTMAP.getFragmentShader()))
+            return original.call(instance, id_, type_);
+
+        return """
+            #version 150
+
+            in vec2 texCoord;
+            out vec4 fragColor;
+
+            void main() {
+                fragColor = vec4(1.0);
+            }
+            """;
+    }
+
+    @Inject(method = "getOrCompilePipeline", at = @At("HEAD"))
+    private void noammaddons$checkFullBrightToggle(RenderPipeline pipeline, CallbackInfoReturnable<GlRenderPipeline> cir) {
+        boolean current = Camera.INSTANCE.enabled && Camera.getFullBright().getValue();
+        if (current == lastFullBright) return;
+        lastFullBright = current;
+        ((GlDevice) (Object) this).clearPipelineCache();
+    }
+}

--- a/src/main/java/com/github/noamm9/mixin/MixinLightTexture.java
+++ b/src/main/java/com/github/noamm9/mixin/MixinLightTexture.java
@@ -1,7 +1,6 @@
 package com.github.noamm9.mixin;
 
 import com.github.noamm9.features.impl.misc.Camera;
-import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.client.renderer.LightTexture;
 import net.minecraft.core.Holder;
@@ -13,12 +12,6 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(LightTexture.class)
 public abstract class MixinLightTexture {
-    @ModifyExpressionValue(method = "updateLightTexture(F)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/OptionInstance;get()Ljava/lang/Object;", ordinal = 2))
-    private Object injectFullBright(Object original) {
-        if (Camera.INSTANCE.enabled && Camera.getFullBright().getValue()) return 99999.0;
-        return original;
-    }
-
     @Redirect(method = "updateLightTexture", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/player/LocalPlayer;getEffectBlendFactor(Lnet/minecraft/core/Holder;F)F"))
     private float injectAntiDarkness(LocalPlayer instance, Holder<MobEffect> registryEntry, float v) {
         if (Camera.INSTANCE.enabled && Camera.getDisableDarkness().getValue() && registryEntry == MobEffects.DARKNESS) return 0f;


### PR DESCRIPTION
## Summary
- Replaces the old gamma 99999 hack with a shader-based fullbright
- The lightmap fragment shader is replaced with `vec4(1.0)` when fullbright is enabled
- Fixes the yellow circle lighting artifacts around light sources

## Changes
- **MixinGlDevice** (new): intercepts `compileShader` to replace the lightmap fragment shader, and hooks `getOrCompilePipeline` to detect toggle changes and clear the pipeline cache
- **MixinLightTexture**: removed `injectFullBright` (gamma 99999), kept `injectAntiDarkness`
- **MixinGameRenderer**: removed `getNightVisionScale` override (no longer needed with shader approach)

## Screens

**before**
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/a4aa203f-4160-4db7-916e-d7f26e99a421" />
**after**
<img width="2560" height="1229" alt="image" src="https://github.com/user-attachments/assets/210e7f5d-6223-4356-b0b4-82bf5986f3fd" />
