### PR TITLE
fix: prevent secret waypoints from being incorrectly marked as completed under certain conditions

### DIFF
--- a/src/main/kotlin/com/github/noamm9/event/EventDispatcher.kt
+++ b/src/main/kotlin/com/github/noamm9/event/EventDispatcher.kt
@@ -76,7 +76,7 @@ object EventDispatcher {
             }
             else if (event.packet is ClientboundSoundPacket) {
                 if (! LocationUtils.inDungeon || LocationUtils.inBoss) return@register
-                if (! event.packet.sound.value().equalsOneOf(SoundEvents.BAT_HURT, SoundEvents.BAT_DEATH)) return@register
+                if (event.packet.sound.value() != SoundEvents.BAT_DEATH) return@register
 
                 EventBus.post(DungeonEvent.SecretEvent(
                     SecretType.BAT,

--- a/src/main/kotlin/com/github/noamm9/event/EventDispatcher.kt
+++ b/src/main/kotlin/com/github/noamm9/event/EventDispatcher.kt
@@ -10,7 +10,6 @@ import com.github.noamm9.utils.dungeons.DungeonUtils.isSecret
 import com.github.noamm9.utils.dungeons.enums.SecretType
 import com.github.noamm9.utils.dungeons.map.core.UniqueRoom
 import com.github.noamm9.utils.dungeons.map.utils.ScanUtils
-import com.github.noamm9.utils.equalsOneOf
 import com.github.noamm9.utils.location.LocationUtils
 import com.github.noamm9.utils.render.RenderContext
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientEntityEvents

--- a/src/main/kotlin/com/github/noamm9/features/impl/dungeon/waypoints/DungeonWaypoints.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/dungeon/waypoints/DungeonWaypoints.kt
@@ -31,6 +31,9 @@ import java.io.FileWriter
 import java.util.concurrent.*
 
 object DungeonWaypoints: Feature("Add a custom waypoint with /ndw add while looking at a block") {
+    private const val MAX_ITEM_MATCH_DISTANCE_SQ = 25.0
+    private const val MAX_BAT_MATCH_DISTANCE_SQ = 144.0
+
     val secretWaypoints by ToggleSetting("Secret Waypoints").section("Secret Waypoints")
     val mode by DropdownSetting("Mode", 0, listOf("Fill", "Outline", "Filled Outline"))
     val phase by ToggleSetting("See Through Walls", true)
@@ -96,14 +99,24 @@ object DungeonWaypoints: Feature("Add a custom waypoint with /ndw add while look
         }
 
         register<DungeonEvent.SecretEvent> {
-            if (! secretWaypoints.value || currentSecrets.isEmpty()) return@register
-            val playerPos = NoammAddons.mc.player?.blockPosition() ?: return@register
+            if (!secretWaypoints.value || currentSecrets.isEmpty()) return@register
             if (event.type == SecretType.LEVER) return@register
-            if (event.pos.distSqr(playerPos) > 36) return@register
 
             val distinctTypes = setOf(SecretType.BAT, SecretType.ITEM)
-            val target = if (event.type !in distinctTypes) currentSecrets.find { it.pos == event.pos }
-            else currentSecrets.filter { it.type in distinctTypes }.minByOrNull { it.pos.distSqr(event.pos) }
+            val target = if (event.type in distinctTypes) {
+                val maxDistance = when (event.type) {
+                    SecretType.ITEM -> MAX_ITEM_MATCH_DISTANCE_SQ
+                    SecretType.BAT -> MAX_BAT_MATCH_DISTANCE_SQ
+                    else -> return@register
+                }
+
+                currentSecrets
+                    .filter { it.type == event.type }
+                    .map { it to it.pos.distSqr(event.pos) }
+                    .minByOrNull { it.second }
+                    ?.takeIf { it.second <= maxDistance }
+                    ?.first
+            } else currentSecrets.find { it.pos == event.pos }
 
             target?.let(currentSecrets::remove)
         }

--- a/src/main/kotlin/com/github/noamm9/features/impl/dungeon/waypoints/DungeonWaypoints.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/dungeon/waypoints/DungeonWaypoints.kt
@@ -31,7 +31,6 @@ import java.io.FileWriter
 import java.util.concurrent.*
 
 object DungeonWaypoints: Feature("Add a custom waypoint with /ndw add while looking at a block") {
-    private const val MAX_ITEM_MATCH_DISTANCE_SQ = 25.0
     private const val MAX_BAT_MATCH_DISTANCE_SQ = 144.0
 
     val secretWaypoints by ToggleSetting("Secret Waypoints").section("Secret Waypoints")
@@ -99,24 +98,21 @@ object DungeonWaypoints: Feature("Add a custom waypoint with /ndw add while look
         }
 
         register<DungeonEvent.SecretEvent> {
-            if (!secretWaypoints.value || currentSecrets.isEmpty()) return@register
+            if (! secretWaypoints.value || currentSecrets.isEmpty()) return@register
             if (event.type == SecretType.LEVER) return@register
 
-            val distinctTypes = setOf(SecretType.BAT, SecretType.ITEM)
-            val target = if (event.type in distinctTypes) {
-                val maxDistance = when (event.type) {
-                    SecretType.ITEM -> MAX_ITEM_MATCH_DISTANCE_SQ
-                    SecretType.BAT -> MAX_BAT_MATCH_DISTANCE_SQ
-                    else -> return@register
-                }
+            val maxDistance = when (event.type) {
+                SecretType.ITEM -> 25
+                SecretType.BAT -> 144
+                else -> Int.MAX_VALUE
+            }
 
-                currentSecrets
-                    .filter { it.type == event.type }
-                    .map { it to it.pos.distSqr(event.pos) }
-                    .minByOrNull { it.second }
-                    ?.takeIf { it.second <= maxDistance }
-                    ?.first
-            } else currentSecrets.find { it.pos == event.pos }
+            val target = currentSecrets.asSequence()
+                .filter { it.type == event.type }
+                .map { it to it.pos.distSqr(event.pos) }
+                .minByOrNull { it.second }
+                ?.takeIf { it.second <= maxDistance }
+                ?.first
 
             target?.let(currentSecrets::remove)
         }

--- a/src/main/kotlin/com/github/noamm9/features/impl/dungeon/waypoints/DungeonWaypoints.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/dungeon/waypoints/DungeonWaypoints.kt
@@ -31,8 +31,6 @@ import java.io.FileWriter
 import java.util.concurrent.*
 
 object DungeonWaypoints: Feature("Add a custom waypoint with /ndw add while looking at a block") {
-    private const val MAX_BAT_MATCH_DISTANCE_SQ = 144.0
-
     val secretWaypoints by ToggleSetting("Secret Waypoints").section("Secret Waypoints")
     val mode by DropdownSetting("Mode", 0, listOf("Fill", "Outline", "Filled Outline"))
     val phase by ToggleSetting("See Through Walls", true)
@@ -42,7 +40,7 @@ object DungeonWaypoints: Feature("Add a custom waypoint with /ndw add while look
     val chestColor by ColorSetting("Chest Color", Color.MAGENTA, false).section("Colors")
     val itemColor by ColorSetting("Item Color", Utils.favoriteColor, false)
     val batColor by ColorSetting("Bat Color", Color.GREEN, false)
-    val essanceColor by ColorSetting("Essance Color", Color.BLACK, false)
+    val essanceColor by ColorSetting("Essence Color", Color.BLACK, false)
     val keyColor by ColorSetting("Redstone Key Color", Color.RED, false)
 
     data class DungeonWaypoint(val pos: BlockPos, val color: Color, val filled: Boolean, val outline: Boolean, val phase: Boolean)


### PR DESCRIPTION
With the previous logic, it was possible-and indeed likely-for an event of SecretType.BAT to mark the closest item (without a distance check!) as completed, and vice versa, causing an unrelated waypoint to disappear.
The restrictive check between the event position and the current player position also caused some bat kills not to register.
This PR fixes bat and item waypoints being incorrectly marked as completed while also improving the reliability of marking bat waypoints as completed when appropriate

On a semi-related note
https://github.com/Noamm9/NoammAddons/blob/61eeefcb960fef94755fd690725b426d9e945126/src/main/kotlin/com/github/noamm9/features/impl/dungeon/waypoints/DungeonWaypoints.kt#L43
https://github.com/Noamm9/NoammAddons/blob/61eeefcb960fef94755fd690725b426d9e945126/src/main/kotlin/com/github/noamm9/utils/dungeons/enums/SecretType.kt#L4
I'm pretty sure the correct spelling is "essence"