### PR TITLE
fix: renderCircle renders incorrectly on 1.21.11

### DIFF
--- a/src/main/kotlin/com/github/noamm9/utils/render/NoammRenderLayers.kt
+++ b/src/main/kotlin/com/github/noamm9/utils/render/NoammRenderLayers.kt
@@ -8,6 +8,8 @@ import net.minecraft.client.renderer.rendertype.RenderType
 object NoammRenderLayers {
     val FILLED = RenderType.create("noamm_filled", RenderSetup.builder(NoammRenderPipelines.FILLED).createRenderSetup())
     val FILLED_THROUGH_WALLS = RenderType.create("noamm_filled_through_walls", RenderSetup.builder(NoammRenderPipelines.FILLED_THROUGH_WALLS).createRenderSetup())
+    val CIRCLE_FILLED = RenderType.create("noamm_circle_filled", RenderSetup.builder(NoammRenderPipelines.CIRCLE_FILLED).createRenderSetup())
+    val CIRCLE_FILLED_THROUGH_WALLS = RenderType.create("noamm_circle_filled_through_walls", RenderSetup.builder(NoammRenderPipelines.CIRCLE_FILLED_THROUGH_WALLS).createRenderSetup())
 
     val LINES = RenderType.create("noamm_lines", RenderSetup.builder(RenderPipelines.LINES).createRenderSetup())
     val LINES_THROUGH_WALLS = RenderType.create("noamm_lines_through_walls", RenderSetup.builder(NoammRenderPipelines.LINES_THROUGH_WALLS).createRenderSetup())

--- a/src/main/kotlin/com/github/noamm9/utils/render/NoammRenderPipelines.kt
+++ b/src/main/kotlin/com/github/noamm9/utils/render/NoammRenderPipelines.kt
@@ -18,6 +18,13 @@ object NoammRenderPipelines {
             .build()
     )
 
+    val CIRCLE_FILLED: RenderPipeline = RenderPipelines.register(
+        RenderPipeline.builder(RenderPipelines.DEBUG_FILLED_SNIPPET)
+            .withLocation(id("pipeline/circle_filled"))
+            .withVertexFormat(DefaultVertexFormat.POSITION_COLOR, VertexFormat.Mode.TRIANGLE_STRIP)
+            .build()
+    )
+
     val LINES_THROUGH_WALLS: RenderPipeline = RenderPipelines.register(
         RenderPipeline.builder(RenderPipelines.LINES_SNIPPET)
             .withLocation(id("pipeline/lines_through_walls"))
@@ -33,9 +40,18 @@ object NoammRenderPipelines {
             .build()
     )
 
+    val CIRCLE_FILLED_THROUGH_WALLS: RenderPipeline = RenderPipelines.register(
+        RenderPipeline.builder(RenderPipelines.DEBUG_FILLED_SNIPPET)
+            .withLocation(id("pipeline/circle_filled_through_walls"))
+            .withVertexFormat(DefaultVertexFormat.POSITION_COLOR, VertexFormat.Mode.TRIANGLE_STRIP)
+            .withDepthTestFunction(DepthTestFunction.NO_DEPTH_TEST)
+            .build()
+    )
+
     fun init() {
         IrisCompatibility.registerPipeline(LINES_THROUGH_WALLS, IrisShaderType.LINES)
         IrisCompatibility.registerPipeline(FILLED_THROUGH_WALLS, IrisShaderType.BASIC)
+        IrisCompatibility.registerPipeline(CIRCLE_FILLED_THROUGH_WALLS, IrisShaderType.BASIC)
     }
 
     private fun id(path: String) = Identifier.fromNamespaceAndPath(NoammAddons.MOD_ID, path)

--- a/src/main/kotlin/com/github/noamm9/utils/render/Render3D.kt
+++ b/src/main/kotlin/com/github/noamm9/utils/render/Render3D.kt
@@ -103,17 +103,16 @@ object Render3D {
         ctx.matrixStack.pushPose()
         ctx.matrixStack.translate(- cameraPos.x, - cameraPos.y, - cameraPos.z)
 
-        val buffer = ctx.consumers.getBuffer(if (phase) NoammRenderLayers.FILLED_THROUGH_WALLS else NoammRenderLayers.FILLED)
+        val buffer = ctx.consumers.getBuffer(if (phase) NoammRenderLayers.CIRCLE_FILLED_THROUGH_WALLS else NoammRenderLayers.CIRCLE_FILLED)
 
         val r = color.red / 255f
         val g = color.green / 255f
         val b = color.blue / 255f
         val a = color.alpha / 255f
         val pose = ctx.matrixStack.last()
-
         val size = thickness.toDouble() / 40.0
-        val innerR = radius - size
-        val outerR = radius + size
+        val innerR = radius.toDouble() - size
+        val outerR = radius.toDouble() + size
         val bottomY = (center.y - size).toFloat()
         val topY = (center.y + size).toFloat()
 
@@ -136,41 +135,25 @@ object Render3D {
             val x2Outer = (center.x + outerR * c2).toFloat()
             val z2Outer = (center.z + outerR * s2).toFloat()
 
-            addQuad(
-                buffer, pose,
-                x1Inner, topY, z1Inner,
-                x1Outer, topY, z1Outer,
-                x2Outer, topY, z2Outer,
-                x2Inner, topY, z2Inner,
-                r, g, b, a
-            )
+            buffer.addVertex(pose, x1Inner, topY, z1Inner).setColor(r, g, b, a)
+            buffer.addVertex(pose, x1Outer, topY, z1Outer).setColor(r, g, b, a)
+            buffer.addVertex(pose, x2Outer, topY, z2Outer).setColor(r, g, b, a)
+            buffer.addVertex(pose, x2Inner, topY, z2Inner).setColor(r, g, b, a)
 
-            addQuad(
-                buffer, pose,
-                x1Outer, bottomY, z1Outer,
-                x1Outer, topY, z1Outer,
-                x2Outer, topY, z2Outer,
-                x2Outer, bottomY, z2Outer,
-                r, g, b, a
-            )
+            buffer.addVertex(pose, x1Outer, bottomY, z1Outer).setColor(r, g, b, a)
+            buffer.addVertex(pose, x1Outer, topY, z1Outer).setColor(r, g, b, a)
+            buffer.addVertex(pose, x2Outer, topY, z2Outer).setColor(r, g, b, a)
+            buffer.addVertex(pose, x2Outer, bottomY, z2Outer).setColor(r, g, b, a)
 
-            addQuad(
-                buffer, pose,
-                x1Inner, bottomY, z1Inner,
-                x1Inner, topY, z1Inner,
-                x2Inner, topY, z2Inner,
-                x2Inner, bottomY, z2Inner,
-                r, g, b, a
-            )
+            buffer.addVertex(pose, x1Inner, bottomY, z1Inner).setColor(r, g, b, a)
+            buffer.addVertex(pose, x1Inner, topY, z1Inner).setColor(r, g, b, a)
+            buffer.addVertex(pose, x2Inner, topY, z2Inner).setColor(r, g, b, a)
+            buffer.addVertex(pose, x2Inner, bottomY, z2Inner).setColor(r, g, b, a)
 
-            addQuad(
-                buffer, pose,
-                x1Inner, bottomY, z1Inner,
-                x1Outer, bottomY, z1Outer,
-                x2Outer, bottomY, z2Outer,
-                x2Inner, bottomY, z2Inner,
-                r, g, b, a
-            )
+            buffer.addVertex(pose, x1Inner, bottomY, z1Inner).setColor(r, g, b, a)
+            buffer.addVertex(pose, x1Outer, bottomY, z1Outer).setColor(r, g, b, a)
+            buffer.addVertex(pose, x2Outer, bottomY, z2Outer).setColor(r, g, b, a)
+            buffer.addVertex(pose, x2Inner, bottomY, z2Inner).setColor(r, g, b, a)
         }
 
         ctx.matrixStack.popPose()


### PR DESCRIPTION
`renderCircle` was rendering incorrectly on 1.21.11, which made things like Gyro Helper look off compared to 1.21.10. This fixes the broken `renderCircle` method without changing the other `Render3D` methods.