### PR TITLE
TermAutoClicker: add left click option and reset missTime

### DIFF
--- a/src/main/kotlin/com/github/noamm9/features/impl/general/TermAutoClicker.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/general/TermAutoClicker.kt
@@ -7,12 +7,14 @@ import com.github.noamm9.features.Feature
 import com.github.noamm9.mixin.IKeyMapping
 import com.github.noamm9.ui.clickgui.components.getValue
 import com.github.noamm9.ui.clickgui.components.impl.SliderSetting
+import com.github.noamm9.ui.clickgui.components.impl.ToggleSetting
 import com.github.noamm9.ui.clickgui.components.provideDelegate
 import com.github.noamm9.ui.clickgui.components.withDescription
 import com.github.noamm9.utils.items.ItemUtils.skyblockId
 
 object TermAutoClicker: Feature(name = "Term AC", description = "Automatically uses Salvation ability when holding right click.") {
     private val cps by SliderSetting("Clicks Per Second", 5, 1, 15, 1).withDescription("How many times per second the autoclicker should click.")
+    private val onLeftClick by ToggleSetting("Activate on left click instead", false)
     private var nextLeftClick = 0L
 
     override fun init() {
@@ -21,7 +23,9 @@ object TermAutoClicker: Feature(name = "Term AC", description = "Automatically u
             val player = mc.player?.takeUnless { it.isUsingItem } ?: return@register
             val now = System.currentTimeMillis()
 
-            if (! mc.options.keyUse.isDown) return@register
+            if (! mc.options.keyUse.isDown && ! onLeftClick.value) return@register
+            if (! mc.options.keyAttack.isDown && onLeftClick.value) return@register
+
             if (player.mainHandItem.skyblockId != "TERMINATOR") return@register
             if (now < nextLeftClick) return@register
 

--- a/src/main/kotlin/com/github/noamm9/features/impl/general/TermAutoClicker.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/general/TermAutoClicker.kt
@@ -31,6 +31,7 @@ object TermAutoClicker: Feature(name = "Term AC", description = "Automatically u
 
             nextLeftClick = getNextClick(now)
             (mc.options.keyAttack as IKeyMapping).clickCount += 1
+            mc.missTime = 0
         }
     }
 


### PR DESCRIPTION
## Summary
- add a left click option for TermAutoClicker
- reset missTime to 0 after handling click logic

## Testing
- not run (small logic change)