### PR TITLE
feat(StorageOverlay): per-page customization, border & spacing sliders

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-# NoammAddons 1.21.10
+# NoammAddons 26.1.2
 
 [![GitHub Downloads](https://img.shields.io/github/downloads/Noamm9/NoammAddons/total?style=for-the-badge&logo=github)](https://github.com/Noamm9/NoammAddons/releases)
 [![Discord](https://img.shields.io/discord/1281979747605418024?color=5865F2&logo=discord&logoColor=white&style=for-the-badge)](https://discord.gg/pj9mQGxMxB)
 
-> 1.21.10 port of the greatest skyblock mod ever!
+> 26.1.2 port of the greatest skyblock mod ever!
 
 ----
 
 ## How to install?
 
-1. Install **[Fabric for Minecraft 1.21.10](https://fabricmc.net/use/installer/)**
-2. Install **[Fabric API](https://cdn.modrinth.com/data/P7dR8mSH/versions/tV4Gc0Zo/fabric-api-0.138.4%2B1.21.10.jar)** and **[Fabric Kotlin Language](https://cdn.modrinth.com/data/Ha28R6CL/versions/N6D3uiZF/fabric-language-kotlin-1.13.8%2Bkotlin.2.3.0.jar)**
-3. Download the latest mod file from the   [**Releases page**](https://github.com/Noamm9/NoammAddons-1.21.10/releases)
+1. Install **[Fabric for Minecraft 26.1.2](https://fabricmc.net/use/installer/)**
+2. Install **[Fabric API](https://modrinth.com/mod/fabric-api/versions?g=26.1.2)** and **[Fabric Kotlin Language](https://modrinth.com/mod/fabric-language-kotlin)**
+3. Download the latest mod file from the [**Releases page**](https://github.com/Noamm9/NoammAddons/releases)
 4. Put the downloaded `.jar` files into your `.minecraft/mods` folder
 5. Launch Minecraft using the **Fabric** profile
 

--- a/src/main/kotlin/com/github/noamm9/features/impl/general/storageoverlay/StorageCustomization.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/general/storageoverlay/StorageCustomization.kt
@@ -1,0 +1,148 @@
+package com.github.noamm9.features.impl.general.storageoverlay
+
+import com.github.noamm9.config.PogObject
+import com.github.noamm9.features.Feature
+import com.github.noamm9.features.impl.dev.ClickGui
+import com.github.noamm9.ui.clickgui.components.Setting
+import com.github.noamm9.ui.clickgui.components.Style
+import com.github.noamm9.ui.clickgui.components.impl.ButtonSetting
+import com.github.noamm9.ui.clickgui.components.impl.CategorySetting
+import com.github.noamm9.ui.clickgui.components.impl.ColorSetting
+import com.github.noamm9.ui.clickgui.components.impl.TextInputSetting
+import com.github.noamm9.ui.clickgui.components.impl.ToggleSetting
+import com.github.noamm9.ui.utils.Animation
+import com.github.noamm9.utils.render.Render2D
+import net.minecraft.client.gui.GuiGraphicsExtractor
+import net.minecraft.network.chat.Component
+import java.awt.Color
+
+/**
+ * Per-page (Ender Chest / Backpack) customization for [StorageOverlay]: the persisted data,
+ * the global store, and the settings accordion. A `null` color means the page follows the
+ * user's accent color.
+ *
+ * Customization is global (shared across Skyblock profiles) and persisted in its own json
+ * rather than the ClickGui config (settings there are keyed by name and would collide across
+ * the 27 identical page fields) - the fields use the existing settings wrapped in [StoreSetting]
+ * so they are never registered with the config and write straight to this store instead.
+ */
+data class PageCustomization(
+    var name: String = "",
+    var color: Int? = null,
+    var alwaysBorder: Boolean = false,
+    var alwaysName: Boolean = false,
+)
+
+object StorageCustomization {
+    private val store = PogObject("storage_customization", hashMapOf<Int, PageCustomization>())
+    private val data get() = store.get()
+
+    private fun customization(index: Int): PageCustomization = data.getOrPut(index) { PageCustomization() }
+    private fun peek(index: Int): PageCustomization? = data[index]
+
+    // The getters run per page per frame; this snapshots the store lookup + name fallback + Color allocation per
+    // page, rebuilt lazily after a setter touches that page. color stays null when following the accent color so
+    // the fallback tracks accent changes live.
+    private class Resolved(val name: String, val color: Color?, val alwaysBorder: Boolean, val alwaysName: Boolean) {
+        // Derived display values, cached here so the overlay doesn't rebuild a Component / concat a string per
+        // visible page per frame (the cached Component also keeps its visual-order-text layout cache warm).
+        val nameComponent: Component = Component.literal(name)
+        val placeholderText = "$name - Click to load"
+    }
+
+    private val resolved = arrayOfNulls<Resolved>(27)
+
+    private fun resolved(index: Int): Resolved = resolved[index] ?: run {
+        val c = peek(index)
+        Resolved(
+            c?.name?.takeIf { it.isNotBlank() } ?: StoragePage(index).name,
+            c?.color?.let { Color(it) },
+            c?.alwaysBorder == true,
+            c?.alwaysName == true
+        ).also { resolved[index] = it }
+    }
+
+    fun nameFor(page: StoragePage): String = resolved(page.index).name
+    fun nameComponentFor(page: StoragePage): Component = resolved(page.index).nameComponent
+    fun placeholderTextFor(page: StoragePage): String = resolved(page.index).placeholderText
+    fun colorFor(index: Int): Color = resolved(index).color ?: ClickGui.accsentColor.value
+    fun alwaysBorderFor(index: Int): Boolean = resolved(index).alwaysBorder
+    fun alwaysNameFor(index: Int): Boolean = resolved(index).alwaysName
+
+    private fun setName(index: Int, name: String) { customization(index).name = name; save(index) }
+    private fun setColor(index: Int, color: Color) { customization(index).color = color.rgb and 0xFFFFFF; save(index) }
+    private fun setAlwaysBorder(index: Int, value: Boolean) { customization(index).alwaysBorder = value; save(index) }
+    private fun setAlwaysName(index: Int, value: Boolean) { customization(index).alwaysName = value; save(index) }
+    private fun reset(index: Int) { data.remove(index); save(index) }
+
+    private fun save(index: Int) {
+        resolved[index] = null
+        store.save()
+    }
+
+    /** Appends the customization accordion (top header -> 27 page headers -> per-page fields). */
+    fun buildSettings(feature: Feature) {
+        val settings = feature.configSettings
+        settings.add(CategorySetting("Customization"))
+        val top = FoldableSetting { "Page Customization" }
+        settings.add(top)
+
+        for (i in 0 until 27) {
+            val page = StoragePage(i)
+            val header = FoldableSetting { nameFor(page) }.also { it.visibility = { top.expanded } }
+            settings.add(header)
+            val visible = { top.expanded && header.expanded }
+
+            fun field(setting: Setting<*>, desc: String) = settings.add(StoreSetting(setting).also { it.visibility = visible; it.description = desc })
+
+            field(TextInputSetting("Name", peek(i)?.name ?: "") { setName(i, it) }, "Custom name for this page. Leave empty for the default.")
+            field(ColorSetting("Border Color", colorFor(i), withAlpha = false) { setColor(i, it) }, "Border color for this page. Defaults to the accent color.")
+            field(ToggleSetting("Always Show Border", alwaysBorderFor(i)) { setAlwaysBorder(i, it) }, "Draw this page's border even when it is not the open page.")
+            field(ToggleSetting("Always Show Name", alwaysNameFor(i)) { setAlwaysName(i, it) }, "Show this page's name even when it is not the open page.")
+            settings.add(ButtonSetting("Reset") { reset(i) }.also { it.visibility = visible; it.description = "Reset this page's customization to defaults." })
+        }
+    }
+}
+
+/** A collapsible header row. Clicking toggles [expanded]; child settings hide/show via a visibility check. */
+class FoldableSetting(private val title: () -> String): Setting<Boolean>("", false) {
+    var expanded = false
+    private val hoverAnim = Animation(200)
+
+    override fun draw(ctx: GuiGraphicsExtractor, mouseX: Int, mouseY: Int) {
+        val isHovered = mouseX >= x && mouseX <= x + width && mouseY >= y && mouseY <= y + height
+        hoverAnim.update(if (isHovered) 1f else 0f)
+
+        Style.drawBackground(ctx, x, y, width, height)
+        Style.drawHoverBar(ctx, x, y, height, hoverAnim.value)
+        Render2D.drawString(ctx, if (expanded) "§7▾" else "§7▸", x + 8f, y + 6f, Color.WHITE)
+        Style.drawNudgedText(ctx, title(), x + 19f, y + 6f, hoverAnim.value)
+    }
+
+    override fun mouseClicked(mouseX: Double, mouseY: Double, button: Int): Boolean {
+        if (button == 0 && mouseX >= x && mouseX <= x + width && mouseY >= y && mouseY <= y + height) {
+            expanded = ! expanded
+            Style.playClickSound(1f)
+            return true
+        }
+        return false
+    }
+}
+
+/**
+ * Renders/behaves exactly like the wrapped [inner] setting but is itself not Savable, and the
+ * inner setting is never registered with the config - so the config never persists it (no name
+ * collisions). Persistence is handled by the store via the inner setting's onChange callback.
+ */
+class StoreSetting(private val inner: Setting<*>): Setting<Unit>(inner.name, Unit) {
+    override val height get() = inner.height
+
+    private fun sync() { inner.x = x; inner.y = y; inner.width = width }
+
+    override fun draw(ctx: GuiGraphicsExtractor, mouseX: Int, mouseY: Int) { sync(); inner.draw(ctx, mouseX, mouseY) }
+    override fun mouseClicked(mouseX: Double, mouseY: Double, button: Int): Boolean { sync(); return inner.mouseClicked(mouseX, mouseY, button) }
+    override fun mouseReleased(button: Int) = inner.mouseReleased(button)
+    override fun mouseScrolled(mouseX: Int, mouseY: Int, delta: Double) = inner.mouseScrolled(mouseX, mouseY, delta)
+    override fun keyPressed(keyCode: Int, scanCode: Int, modifiers: Int) = inner.keyPressed(keyCode, scanCode, modifiers)
+    override fun charTyped(codePoint: Char) = inner.charTyped(codePoint)
+}

--- a/src/main/kotlin/com/github/noamm9/features/impl/general/storageoverlay/StorageOverlay.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/general/storageoverlay/StorageOverlay.kt
@@ -30,9 +30,11 @@ import kotlin.jvm.optionals.getOrNull
 object StorageOverlay: Feature("Shows all storage pages in an overlay when opening storage.", toggled = true) {
     val scaleSetting by SliderSetting("Scale", 1.0f, 0.5f, 2.0f, 0.05f).withDescription("The scale of the menu")
     val columnsSetting by SliderSetting("Columns", 3, 1, 10, 1).withDescription("The number of pages to show next to each other horizontally")
-    val maxHeightSetting by SliderSetting("Max Height", 324, 80, 600, 1).withDescription("the maximum height of the entire menu")
-    val scrollSpeedSetting by SliderSetting("Scroll Speed", 10, 1, 50, 1).withDescription("how fast you scroll")
-    val retainScrollSetting by ToggleSetting("Retain Scroll", true).withDescription("Whether to it keep the scroll offset after closing the menu")
+    val maxHeightSetting by SliderSetting("Max Height", 324, 80, 600, 1).withDescription("The maximum height of the entire menu")
+    val borderThicknessSetting by SliderSetting("Border Thickness", 2f, 0.5f, 3f, 0.5f).withDescription("The thickness of the page borders")
+    val pageSpacingSetting by SliderSetting("Page Spacing", 6, 0, 20, 1).withDescription("The vertical space between page rows")
+    val scrollSpeedSetting by SliderSetting("Scroll Speed", 10, 1, 50, 1).withDescription("How fast you scroll")
+    val retainScrollSetting by ToggleSetting("Retain Scroll", true).withDescription("Whether to keep the scroll offset after closing the menu")
     val enableTooltipInStorage by ToggleSetting("Tooltip Scroll").withDescription("Whether to enable Item Tooltip Scrolling. (requires ${ScrollableTooltip.name} to be enabled)")
 
     private val storageDir by lazy { File(mc.gameDirectory, "config/${NoammAddons.MOD_NAME}/storage").also(File::mkdirs) }
@@ -54,6 +56,8 @@ object StorageOverlay: Feature("Shows all storage pages in an overlay when openi
     )
 
     override fun init() {
+        StorageCustomization.buildSettings(this)
+
         register<ContainerFullyOpenedEvent> {
             if (! LocationUtils.inSkyblock) return@register
             val screen = mc.screen as? ContainerScreen ?: return@register
@@ -88,7 +92,7 @@ object StorageOverlay: Feature("Shows all storage pages in an overlay when openi
         val menu = StorageMenu.get(screen)
         val overlay = oldScreen as? StorageOverlayScreen ?: active
 
-        if (currentMenu == null && menu == null) loadData()
+        if (currentMenu == null && menu == null) ThreadUtils.async(::loadData)
         currentMenu?.let(::saveContent)
         menu?.let(::saveContent)
         currentMenu = menu
@@ -170,7 +174,10 @@ object StorageOverlay: Feature("Shows all storage pages in an overlay when openi
         val file = dataFile
         if (! checkFile(file)) return
         if (storageMenuData.isNotEmpty()) return
-        if (! file.exists()) return ThreadUtils.async(::loadFromApi)
+        if (! file.exists()) {
+            loadFromApi()
+            return
+        }
         val root = NbtIo.readCompressed(file.toPath(), NbtAccounter.unlimitedHeap())
         val data = TreeMap<StoragePage, NBTInventory?>()
 

--- a/src/main/kotlin/com/github/noamm9/features/impl/general/storageoverlay/StorageOverlayScreen.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/general/storageoverlay/StorageOverlayScreen.kt
@@ -3,7 +3,6 @@
 package com.github.noamm9.features.impl.general.storageoverlay
 
 import com.github.noamm9.NoammAddons.mc
-import com.github.noamm9.features.impl.dev.ClickGui
 import com.github.noamm9.features.impl.general.FEAT_ItemRarity
 import com.github.noamm9.features.impl.misc.InventorySearch
 import com.github.noamm9.features.impl.misc.ScrollableTooltip
@@ -13,18 +12,21 @@ import com.github.noamm9.utils.ColorUtils.withAlpha
 import com.github.noamm9.utils.render.ItemRenderer
 import com.github.noamm9.utils.render.Render2D
 import net.minecraft.client.gui.GuiGraphicsExtractor
+import net.minecraft.core.component.DataComponents
 import net.minecraft.client.gui.screens.Screen
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen
 import net.minecraft.client.gui.screens.inventory.ContainerScreen
 import net.minecraft.client.input.MouseButtonEvent
 import net.minecraft.network.chat.Component
 import net.minecraft.world.entity.player.Inventory
+import net.minecraft.world.inventory.ChestMenu
 import net.minecraft.world.inventory.ContainerInput
 import net.minecraft.world.inventory.Slot
 import net.minecraft.world.item.ItemStack
 import org.lwjgl.glfw.GLFW
 import java.awt.Color
 import java.util.*
+import kotlin.math.ceil
 
 private inline fun inRect(mx: Double, my: Double, x: Int, y: Int, w: Int, h: Int) = mx >= x && mx < x + w && my >= y && my < y + h
 private inline fun inRect(mx: Int, my: Int, x: Int, y: Int, w: Int, h: Int) = mx >= x && mx < x + w && my >= y && my < y + h
@@ -34,7 +36,6 @@ class StorageOverlayScreen: Screen(Component.literal("Storage Overlay")) {
         const val SLOT_SIZE = 17 /// 17x17 instead of 16x16 because the border thickness is 1
         const val PADDING = 10
         const val PAGE_WIDTH = SLOT_SIZE * 9 + 4
-        const val ACTIVE_PAGE_BORDER_THICKNESS = 2
         const val SCROLL_BAR_WIDTH = 8
         const val SCROLL_BAR_HEIGHT = 16
         const val PLAYER_WIDTH = SLOT_SIZE * 9 + 6
@@ -49,9 +50,11 @@ class StorageOverlayScreen: Screen(Component.literal("Storage Overlay")) {
     private val slotBgColor = Color(50, 50, 55, 200)
     private val slotCellBg = Color(30, 30, 34).rgb
     private val slotCellBorder = Color(55, 55, 60).rgb
-    private val activePageBorder get() = ClickGui.accsentColor.value
     private val scrollBgColor = Color(30, 30, 35, 180)
     private val scrollKnobColor = Color(120, 120, 130)
+    private val placeholderTextColor = Color(180, 180, 180)
+    private val borderThickness get() = StorageOverlay.borderThicknessSetting.value
+    private val pageGap get() = StorageOverlay.pageSpacingSetting.value
 
     var isExiting = false
     private var pageWidthCount = StorageOverlay.columnsSetting.value
@@ -101,9 +104,9 @@ class StorageOverlayScreen: Screen(Component.literal("Storage Overlay")) {
         var y = 0
         var center = - 1f
         for (row in rows) {
-            val rowH = row.maxOf { (_, inv) -> inv?.let { it.rows * SLOT_SIZE + 6 + font.lineHeight } ?: 18 }
+            val rowH = row.maxOf { (_, inv) -> inv?.let { it.rows * SLOT_SIZE + 8 + font.lineHeight } ?: 18 }
             if (row.any { (page, _) -> page == target }) center = y + rowH / 2f - scrollPanelH / 2f
-            y += rowH
+            y += rowH + pageGap
         }
         if (center < 0) return
         scroll = center.coerceIn(0f, (y + 6f - scrollPanelH).coerceAtLeast(0f))
@@ -117,8 +120,24 @@ class StorageOverlayScreen: Screen(Component.literal("Storage Overlay")) {
         ScrollableTooltip.scaleOverride = 0f
     }
 
+    // Hovering re-extracts the full tooltip from the stack every frame; cache the lines until the hovered
+    // stack changes. Storage stacks are immutable NBTInventory snapshots so identity is enough; the count
+    // check covers live player-inventory stacks mutating in place.
+    private var tooltipStack: ItemStack? = null
+    private var tooltipCount = 0
+    private var tooltipLines: List<Component> = emptyList()
+
+    private fun GuiGraphicsExtractor.drawCachedTooltip(stack: ItemStack, x: Int, y: Int) {
+        if (tooltipStack !== stack || tooltipCount != stack.count) {
+            tooltipStack = stack
+            tooltipCount = stack.count
+            tooltipLines = getTooltipFromItem(mc, stack)
+        }
+        setTooltipForNextFrame(font, tooltipLines, stack.tooltipImage, x, y, stack.get(DataComponents.TOOLTIP_STYLE))
+    }
+
     private fun GuiGraphicsExtractor.drawPages(mouseX: Int, mouseY: Int, excluding: StoragePage?, slots: List<Slot>?, originalMouseX: Int, originalMouseY: Int) {
-        enableScissor(scrollPanelX, scrollPanelY, scrollPanelX + scrollPanelW + ACTIVE_PAGE_BORDER_THICKNESS, scrollPanelY + scrollPanelH)
+        enableScissor(scrollPanelX, scrollPanelY, scrollPanelX + scrollPanelW + ceil(borderThickness).toInt(), scrollPanelY + scrollPanelH)
         val data = StorageOverlay.storageMenuData
         val viewTop = scrollPanelY
         val viewBottom = scrollPanelY + scrollPanelH
@@ -132,7 +151,7 @@ class StorageOverlayScreen: Screen(Component.literal("Storage Overlay")) {
     }
 
     private fun GuiGraphicsExtractor.drawPagesDecorations(excluding: StoragePage?, slots: List<Slot>?) {
-        enableScissor(scrollPanelX, scrollPanelY, scrollPanelX + scrollPanelW + ACTIVE_PAGE_BORDER_THICKNESS, scrollPanelY + scrollPanelH)
+        enableScissor(scrollPanelX, scrollPanelY, scrollPanelX + scrollPanelW + ceil(borderThickness).toInt(), scrollPanelY + scrollPanelH)
         val data = StorageOverlay.storageMenuData
         val viewTop = scrollPanelY
         val viewBottom = scrollPanelY + scrollPanelH
@@ -228,7 +247,7 @@ class StorageOverlayScreen: Screen(Component.literal("Storage Overlay")) {
 
         if (hoveredStack != null) {
             hoveredOverlayItem = hoveredStack
-            setTooltipForNextFrame(font, hoveredStack, originalMouseX, originalMouseY)
+            drawCachedTooltip(hoveredStack, originalMouseX, originalMouseY)
         }
     }
 
@@ -241,25 +260,28 @@ class StorageOverlayScreen: Screen(Component.literal("Storage Overlay")) {
         }
     }
 
-    private fun GuiGraphicsExtractor.drawPage(x: Int, y: Int, page: StoragePage, inventory: NBTInventory?, slots: List<Slot>?, mouseX: Int, mouseY: Int, originalMouseX: Int, originalMouseY: Int): Int {
+    private fun GuiGraphicsExtractor.drawPage(x: Int, y: Int, page: StoragePage, inventory: NBTInventory?, slots: List<Slot>?, mouseX: Int, mouseY: Int, originalMouseX: Int, originalMouseY: Int) {
         if (inventory == null && slots == null) {
+            val placeholderBorder = if (StorageCustomization.alwaysBorderFor(page.index)) StorageCustomization.colorFor(page.index) else menuBorderColor
             Render2D.drawRect(this, x, y, PAGE_WIDTH, 18, slotBgColor)
-            Render2D.drawBorder(this, x, y, PAGE_WIDTH, 18, menuBorderColor)
-            Render2D.drawString(this, page.name + " - Click to load", x + 4f, y + 5f, Color(180, 180, 180))
-            return 18
+            Render2D.drawBorder(this, x, y, PAGE_WIDTH, 18, placeholderBorder)
+            Render2D.drawString(this, StorageCustomization.placeholderTextFor(page), x + 4f, y + 5f, placeholderTextColor)
+            return
         }
         val rows = inventory?.rows ?: (slots?.size?.div(9)?.coerceIn(1, 5) ?: 3)
 
-        val name = page.name
         val isActive = slots != null
+        val showBorder = isActive || StorageCustomization.alwaysBorderFor(page.index)
+        val showName = isActive || StorageCustomization.alwaysNameFor(page.index)
+        val pageColor = StorageCustomization.colorFor(page.index)
         val slotsY = y + 5 + font.lineHeight
         val pageHeight = rows * SLOT_SIZE + 8 + font.lineHeight
 
-        if (isActive) {
-            Render2D.drawBorder(this, x, y, PAGE_WIDTH + 1, pageHeight, activePageBorder, ACTIVE_PAGE_BORDER_THICKNESS)
+        if (showBorder) {
+            Render2D.drawBorder(this, x, y, PAGE_WIDTH + 1, pageHeight, pageColor, borderThickness)
         }
 
-        text(font, Component.literal(name), x + 6, y + 3, if (isActive) activePageBorder.rgb else 0xFFFFFF, true)
+        if (showName) text(font, StorageCustomization.nameComponentFor(page), x + 6, y + 3, pageColor.rgb, true)
 
         val panelX = scrollPanelX
         val panelY = scrollPanelY
@@ -298,10 +320,8 @@ class StorageOverlayScreen: Screen(Component.literal("Storage Overlay")) {
 
         if (hoveredStack != null) {
             if (isActive) hoveredOverlayItem = hoveredStack
-            setTooltipForNextFrame(font, hoveredStack, originalMouseX, originalMouseY)
+            drawCachedTooltip(hoveredStack, originalMouseX, originalMouseY)
         }
-
-        return pageHeight + 6
     }
 
     private inline fun layoutedForEach(data: SortedMap<StoragePage, NBTInventory?>, func: (x: Int, y: Int, pageWidth: Int, pageHeight: Int, page: StoragePage, inventory: NBTInventory?) -> Unit) {
@@ -309,14 +329,14 @@ class StorageOverlayScreen: Screen(Component.literal("Storage Overlay")) {
         var xOffset = 0
         var maxHeight = 0
         for ((page, inventory) in data.entries) {
-            val currentHeight = inventory?.let { it.rows * SLOT_SIZE + 6 + font.lineHeight } ?: 18
+            val currentHeight = inventory?.let { it.rows * SLOT_SIZE + 8 + font.lineHeight } ?: 18
             maxHeight = maxOf(maxHeight, currentHeight)
             val rectX = measurements.x + PADDING + (PAGE_WIDTH + PADDING) * xOffset
             val rectY = yOffset + measurements.y + PADDING
             func(rectX, rectY, PAGE_WIDTH, currentHeight, page, inventory)
             xOffset ++
             if (xOffset >= pageWidthCount) {
-                yOffset += maxHeight
+                yOffset += maxHeight + pageGap
                 xOffset = 0
                 maxHeight = 0
             }
@@ -324,10 +344,13 @@ class StorageOverlayScreen: Screen(Component.literal("Storage Overlay")) {
         lastRenderedInnerHeight = maxHeight + yOffset + scroll.toInt()
     }
 
+    /** The container's storage slots, excluding the top filler row and the trailing player inventory. */
+    private fun chestSlots(menu: ChestMenu) = menu.slots.take(menu.rowCount * 9).drop(9)
+
     private fun dispatchActivePageSlotClick(button: Int, modifiers: Int, mouseX: Double, mouseY: Double, activePage: StoragePage): Boolean {
         val containerScreen = mc.screen as? AbstractContainerScreen<*> ?: return false
-        val menu = containerScreen.menu
-        val chestSlots = menu.slots.take(menu.slots.size - 36).drop(9)
+        val menu = containerScreen.menu as? ChestMenu ?: return false
+        val chestSlots = chestSlots(menu)
         if (chestSlots.isEmpty()) return false
 
         var hit = - 1
@@ -455,7 +478,7 @@ class StorageOverlayScreen: Screen(Component.literal("Storage Overlay")) {
         Render2D.drawRect(context, measurements.x, measurements.y, measurements.overviewWidth, measurements.overviewHeight, menuBackgroundColor)
         Render2D.drawBorder(context, measurements.x, measurements.y, measurements.overviewWidth, measurements.overviewHeight, Color(60, 60, 65))
         val activeSlot = (storageMenu as? StorageMenu.Page)?.storagePage
-        val chestSlots = screen.menu.slots.take(screen.menu.rowCount * 9).drop(9)
+        val chestSlots = chestSlots(screen.menu)
 
         context.drawPages(scaledMouseX, scaledMouseY, activeSlot, chestSlots, mouseX, mouseY)
         context.drawScrollBar()

--- a/src/main/kotlin/com/github/noamm9/ui/clickgui/components/impl/ColorSetting.kt
+++ b/src/main/kotlin/com/github/noamm9/ui/clickgui/components/impl/ColorSetting.kt
@@ -16,7 +16,7 @@ import org.lwjgl.glfw.GLFW
 import java.awt.Color
 import java.util.*
 
-class ColorSetting(name: String, defaultValue: Color, val withAlpha: Boolean = true): Setting<Color>(name, defaultValue), Savable {
+class ColorSetting(name: String, defaultValue: Color, val withAlpha: Boolean = true, private val onChange: ((Color) -> Unit)? = null): Setting<Color>(name, defaultValue), Savable {
     private var expanded = false
     private val openAnim = Animation(250)
     private val hoverAnim = Animation(200)
@@ -45,6 +45,7 @@ class ColorSetting(name: String, defaultValue: Color, val withAlpha: Boolean = t
         val rgb = Color.HSBtoRGB(h, s, b)
         super.value = Color(rgb).withAlpha((a * 255).toInt())
         updateHexText()
+        onChange?.invoke(value)
     }
 
     private fun updateHexText() {
@@ -170,6 +171,7 @@ class ColorSetting(name: String, defaultValue: Color, val withAlpha: Boolean = t
             a = c.alpha / 255f
 
             super.value = c
+            onChange?.invoke(c)
         }
     }
 

--- a/src/main/kotlin/com/github/noamm9/ui/clickgui/components/impl/TextInputSetting.kt
+++ b/src/main/kotlin/com/github/noamm9/ui/clickgui/components/impl/TextInputSetting.kt
@@ -18,10 +18,10 @@ import net.minecraft.client.input.MouseButtonInfo
 import org.lwjgl.glfw.GLFW
 import java.awt.Color
 
-class TextInputSetting(name: String, defaultValue: String): Setting<String>(name, defaultValue), Savable {
+class TextInputSetting(name: String, defaultValue: String, private val onChange: ((String) -> Unit)? = null): Setting<String>(name, defaultValue), Savable {
     private val handler = TextInputHandler(
         textProvider = { value },
-        textSetter = { value = it }
+        textSetter = { value = it; onChange?.invoke(it) }
     )
 
     private val hoverAnim = Animation(200L)

--- a/src/main/kotlin/com/github/noamm9/ui/clickgui/components/impl/ToggleSetting.kt
+++ b/src/main/kotlin/com/github/noamm9/ui/clickgui/components/impl/ToggleSetting.kt
@@ -13,7 +13,7 @@ import kotlinx.serialization.json.jsonPrimitive
 import net.minecraft.client.gui.GuiGraphicsExtractor
 import java.awt.Color
 
-class ToggleSetting(name: String, value: Boolean = false): Setting<Boolean>(name, value), Savable {
+class ToggleSetting(name: String, value: Boolean = false, private val onChange: ((Boolean) -> Unit)? = null): Setting<Boolean>(name, value), Savable {
     private val toggleAnim = Animation(200, if (value) 1f else 0f)
     private val hoverAnim = Animation(200, 0f)
 
@@ -38,6 +38,7 @@ class ToggleSetting(name: String, value: Boolean = false): Setting<Boolean>(name
     override fun mouseClicked(mouseX: Double, mouseY: Double, button: Int): Boolean {
         if (button == 0 && mouseX >= x && mouseX <= x + width && mouseY >= y && mouseY <= y + height) {
             value = ! value
+            onChange?.invoke(value)
             Style.playClickSound(1f)
             return true
         }

--- a/src/main/kotlin/com/github/noamm9/utils/render/Render2D.kt
+++ b/src/main/kotlin/com/github/noamm9/utils/render/Render2D.kt
@@ -24,10 +24,17 @@ object Render2D {
     }
 
     fun drawRect(ctx: GuiGraphicsExtractor, x: Number, y: Number, width: Number, height: Number, color: Color = Color.WHITE) {
+        // fill only takes ints, so fractional sizes are drawn by scaling a 1x1 quad - the rect covers
+        // exactly width x height in float space (integer sizes render identically to a plain fill).
+        val w = width.toFloat()
+        val h = height.toFloat()
+        if (w <= 0f || h <= 0f) return
         val pose = ctx.pose()
+        pose.pushMatrix()
         pose.translate(x.toFloat(), y.toFloat())
-        ctx.fill(0, 0, width.toInt(), height.toInt(), color.rgb)
-        pose.translate(- x.toFloat(), - y.toFloat())
+        pose.scale(w, h)
+        ctx.fill(0, 0, 1, 1, color.rgb)
+        pose.popMatrix()
     }
 
     fun drawBorder(ctx: GuiGraphicsExtractor, x: Number, y: Number, width: Number, height: Number, color: Color = Color.WHITE, thickness: Number = 1) {


### PR DESCRIPTION
- Per-page customization (custom name, border color, always show border/name, per-page reset) via a foldable accordion in the feature settings, persisted globally in storage_customization.json
- Border Thickness (0.5-3) and Page Spacing (0-20) sliders
- Render2D.drawRect now draws fractional sizes exactly (scaled 1x1 quad), so border segments join seamlessly at any thickness
- Fix page rows overlapping by 2px (layout used a smaller height than the drawn page box)
- Cache hovered-item tooltip lines instead of rebuilding them every frame
- Load storage data off the main thread
- Optional onChange callback on Toggle/TextInput/Color settings

not for merge rn