### PR TITLE
docs: update README for 26.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-# NoammAddons 1.21.10
+# NoammAddons 26.1.2
 
 [![GitHub Downloads](https://img.shields.io/github/downloads/Noamm9/NoammAddons/total?style=for-the-badge&logo=github)](https://github.com/Noamm9/NoammAddons/releases)
 [![Discord](https://img.shields.io/discord/1281979747605418024?color=5865F2&logo=discord&logoColor=white&style=for-the-badge)](https://discord.gg/pj9mQGxMxB)
 
-> 1.21.10 port of the greatest skyblock mod ever!
+> 26.1.2 port of the greatest skyblock mod ever!
 
 ----
 
 ## How to install?
 
-1. Install **[Fabric for Minecraft 1.21.10](https://fabricmc.net/use/installer/)**
-2. Install **[Fabric API](https://cdn.modrinth.com/data/P7dR8mSH/versions/tV4Gc0Zo/fabric-api-0.138.4%2B1.21.10.jar)** and **[Fabric Kotlin Language](https://cdn.modrinth.com/data/Ha28R6CL/versions/N6D3uiZF/fabric-language-kotlin-1.13.8%2Bkotlin.2.3.0.jar)**
-3. Download the latest mod file from the   [**Releases page**](https://github.com/Noamm9/NoammAddons-1.21.10/releases)
+1. Install **[Fabric for Minecraft 26.1.2](https://fabricmc.net/use/installer/)**
+2. Install **[Fabric API](https://modrinth.com/mod/fabric-api/versions?g=26.1.2)** and **[Fabric Kotlin Language](https://modrinth.com/mod/fabric-language-kotlin)**
+3. Download the latest mod file from the [**Releases page**](https://github.com/Noamm9/NoammAddons/releases)
 4. Put the downloaded `.jar` files into your `.minecraft/mods` folder
 5. Launch Minecraft using the **Fabric** profile
 


### PR DESCRIPTION
Updates the README naming and install links for 26.1.2 (Fabric API / Kotlin links now point
  to Modrinth version pages instead of pinned CDN jars, releases link fixed).