### PR TITLE
fix: ScrollableTooltip negative scale

### DIFF
--- a/src/main/java/com/github/noamm9/mixin/MixinGuiGraphicsExtractor.java
+++ b/src/main/java/com/github/noamm9/mixin/MixinGuiGraphicsExtractor.java
@@ -29,7 +29,7 @@ public abstract class MixinGuiGraphicsExtractor {
         else {
             pose.pushMatrix();
             pose.translate(xo, yo);
-            pose.scale((1 * (ScrollableTooltip.INSTANCE.getScale().getValue().floatValue() / 100f)) + ScrollableTooltip.scaleOverride / 10);
+            pose.scale(ScrollableTooltip.INSTANCE.getScale().getValue().floatValue() / 100f + ScrollableTooltip.scaleOverride / 10f);
             pose.translate(ScrollableTooltip.scrollAmountX, ScrollableTooltip.scrollAmountY);
             pose.translate(-xo, -yo);
             original.call(font, lines, xo, yo, positioner, style);

--- a/src/main/kotlin/com/github/noamm9/features/impl/general/storageoverlay/StorageOverlayScreen.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/general/storageoverlay/StorageOverlayScreen.kt
@@ -373,7 +373,7 @@ class StorageOverlayScreen: Screen(Component.literal("Storage Overlay")) {
             val holdingCtrl = GLFW.glfwGetKey(mc.window.handle(), GLFW.GLFW_KEY_LEFT_CONTROL) == GLFW.GLFW_PRESS
             when {
                 holdingShift && ! holdingCtrl -> ScrollableTooltip.scrollAmountX -= scroll
-                ! holdingShift && holdingCtrl -> ScrollableTooltip.scaleOverride += (verticalAmount / 10f).toFloat() * ScrollableTooltip.scaleSpeed.value.toFloat()
+                ! holdingShift && holdingCtrl -> ScrollableTooltip.applyScaleScroll(verticalAmount)
                 else -> ScrollableTooltip.scrollAmountY += scroll
             }
             return true

--- a/src/main/kotlin/com/github/noamm9/features/impl/misc/ScrollableTooltip.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/misc/ScrollableTooltip.kt
@@ -48,11 +48,18 @@ object ScrollableTooltip: Feature("Allows you to scroll through long tooltips.")
                 val holdingCtrl = GLFW.glfwGetKey(mc.window.handle(), GLFW.GLFW_KEY_LEFT_CONTROL) == GLFW.GLFW_PRESS
 
                 if (holdingShift && ! holdingCtrl) scrollAmountX -= scroll
-                else if (! holdingShift && holdingCtrl) scaleOverride += (verticalAmount / 10f).toFloat() * scaleSpeed.value.toFloat()
+                else if (! holdingShift && holdingCtrl) applyScaleScroll(verticalAmount)
                 else scrollAmountY += scroll
 
                 true
             }
         }
+    }
+
+    @JvmStatic
+    internal fun applyScaleScroll(verticalAmount: Double) {
+        val baseScale = scale.value.toFloat() / 100f
+        val nextScale = (baseScale + scaleOverride / 10f + (verticalAmount / 100f).toFloat() * scaleSpeed.value.toFloat()).coerceIn(0.3f, 2.0f)
+        scaleOverride = (nextScale - baseScale) * 10f
     }
 }


### PR DESCRIPTION
Fixes ScrollableTooltip rendering incorrectly when the scale goes below zero

  Before:

<img width="720" height="1196" alt="image" src="https://github.com/user-attachments/assets/55480d02-aae2-40bf-8604-59f516b043db" />