### PR TITLE
Add S/S+ time toggle to Party Finder auto kick

### DIFF
--- a/src/main/kotlin/com/github/noamm9/features/impl/dungeon/PartyFinder.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/dungeon/PartyFinder.kt
@@ -44,8 +44,9 @@ object PartyFinder: Feature() {
     private val autoKick by ToggleSetting("Auto Kick", false).withDescription("Automatically kick players that don't meet requirements.").section("Auto Kick")
     private val autoKickFloor by DropdownSetting("Floor", 6, listOf("F1", "F2", "F3", "F4", "F5", "F6", "F7")).showIf { autoKick.value }
     private val masterMode by ToggleSetting("Master Mode", true).showIf { autoKick.value }
+    private val timeType by DropdownSetting("Time Type", 0, listOf("S+", "S")).withDescription("Check S+ completion times or S completion times.").showIf { autoKick.value }
     private val informKicked by ToggleSetting("Inform Kicked", false).withDescription("Send a party chat message before kicking.").showIf { autoKick.value }
-    private val maximumSeconds by SliderSetting("Maximum Seconds", 400, 60, 480, 10, suffix = "s").withDescription("Maximum S+ PB time in seconds.").showIf { autoKick.value }
+    private val maximumSeconds by SliderSetting("Maximum Seconds", 400, 60, 480, 10, suffix = "s").withDescription("Maximum PB time in seconds.").showIf { autoKick.value }
     private val minimumSecrets by SliderSetting("Minimum Secrets", 0, 0, 200, 1, suffix = "k").withDescription("Minimum secrets in thousands.").showIf { autoKick.value }
 
     private val dungeonGroupJoinRegex = Regex("^Party Finder > (\\w{1,16}) joined the dungeon group! \\((\\w+) Level (\\d+)\\)$")
@@ -309,10 +310,14 @@ object PartyFinder: Feature() {
             val floor = autoKickFloor.value + 1
             val dungeonType = if (masterMode.value) dungeons.masterCatacombs else dungeons.catacombs
 
+            val useSPlus = timeType.value == 0
+            val rank = if (useSPlus) "S+" else "S"
+            val times = if (useSPlus) dungeonType.fastestTimeSPlus else dungeonType.fastestTimeS
+
             val floorPrefix = if (masterMode.value) "M" else "F"
             val pbReq = formatTime(maximumSeconds.value * 1000)
-            val pb = dungeonType.fastestTimeSPlus["$floor"]
-            if (pb == null) add("PB(No S+/$pbReq)")
+            val pb = times["$floor"]
+            if (pb == null) add("PB(No $rank/$pbReq)")
             else if (pb / 1000 > maximumSeconds.value) {
                 add("$floorPrefix$floor: PB(${formatTime(pb)}/$pbReq)")
             }

--- a/src/main/kotlin/com/github/noamm9/utils/network/data/DungeonStats.kt
+++ b/src/main/kotlin/com/github/noamm9/utils/network/data/DungeonStats.kt
@@ -36,7 +36,8 @@ data class DungeonStats(
     @Serializable
     data class TierData(
         @SerialName("tier_completions") val tierCompletions: Map<String, Int>,
-        @SerialName("fastest_time_s_plus") val fastestTimeSPlus: Map<String, Long>
+        @SerialName("fastest_time_s") val fastestTimeS: Map<String, Long> = emptyMap(),
+        @SerialName("fastest_time_s_plus") val fastestTimeSPlus: Map<String, Long> = emptyMap()
     )
 
     @Serializable


### PR DESCRIPTION
## What

Adds a **"Time Type"** dropdown (S+ / S) to the Party Finder **Auto Kick** feature, letting the party leader gate joining players on either **S** or **S+** completion times. Currently auto kick only checks S+ times.

## Why

Some parties run requirements based on S completions rather than S+ (e.g. lower-requirement carries or floors where S is the relevant benchmark). This makes the PB time check configurable instead of hardcoded to S+.

## Changes

- **`DungeonStats.TierData`**: added the `fastest_time_s` map alongside the existing `fastest_time_s_plus`. Both maps now default to `emptyMap()` so a player missing one of them doesn't fail deserialization.
- **`PartyFinder`**: new `Time Type` dropdown (`S+` default, `S`), shown when Auto Kick is enabled. The PB lookup now reads `fastestTimeS` when `S` is selected, otherwise `fastestTimeSPlus`.
- Kick reason text now reports the checked rank, e.g. `PB(No S/6:40)`.
- Tweaked the "Maximum Seconds" description (no longer S+ specific).

Defaults to `S+`, so existing setups are unaffected.

## Testing

- `./gradlew build` passes (all variants compile clean).
