### PR TITLE
fix: stop the storage overlay from disabling SkyBlock Item List everywhere

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,7 @@ val mod_name: String by project
 val fabric_version: String by project
 val modmenu_version: String by project
 val iris_version: String by project
+val itemlist_version: String by project
 val ktor_version: String by project
 
 version = mod_version
@@ -62,6 +63,7 @@ dependencies {
 
     runtimeOnly("me.djtheredstoner:DevAuth-fabric:1.2.2")
     compileOnly("maven.modrinth:iris:$iris_version")
+    compileOnly("maven.modrinth:skyblock-item-list:$itemlist_version")
     compileOnly("com.terraformersmc:modmenu:$modmenu_version")
 
     implementation("io.github.llamalad7:mixinextras-fabric:0.4.1")

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,4 +12,6 @@ mod_name=NoammAddons
 modmenu_version=18.0.0-beta.1
 fabric_version=0.150.0+26.1.2
 iris_version=1.10.8+26.1-fabric
+# modrinth version id for skyblock-item-list 0.0.15+26.1.2 (version numbers collide on the +metadata)
+itemlist_version=jkUMnNQi
 ktor_version=3.4.3

--- a/src/main/kotlin/com/github/noamm9/features/impl/general/storageoverlay/StorageItemListPlugin.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/general/storageoverlay/StorageItemListPlugin.kt
@@ -1,0 +1,24 @@
+package com.github.noamm9.features.impl.general.storageoverlay
+
+import com.github.noamm9.NoammAddons
+import com.operationpotato.itemlist.api.ExcludedScreensManager
+import com.operationpotato.itemlist.api.Plugin
+import net.minecraft.client.gui.screens.inventory.ContainerScreen
+import java.util.Optional
+
+/**
+ * Hides the SkyBlock Item List panel while our storage overlay owns the container screen.
+ * Without this the item list reads our full-width imageWidth, hides itself and persists
+ * its enabled flag to false on close.
+ *
+ * @see resources/fabric.mod.json5
+ */
+@Suppress("unused")
+class StorageItemListPlugin: Plugin {
+    override fun registerExcludedScreens(excludedScreensManager: ExcludedScreensManager) {
+        excludedScreensManager.addProvider(ContainerScreen::class.java) { screen ->
+            if (StorageOverlay.activeFor(screen) != null) Optional.of(NoammAddons.MOD_NAME)
+            else Optional.empty()
+        }
+    }
+}

--- a/src/main/resources/fabric.mod.json5
+++ b/src/main/resources/fabric.mod.json5
@@ -28,6 +28,12 @@
         "value": "com.github.noamm9.NoammAddons",
         "adapter": "kotlin"
       }
+    ],
+    "skyblock-item-list": [
+      {
+        "value": "com.github.noamm9.features.impl.general.storageoverlay.StorageItemListPlugin",
+        "adapter": "kotlin"
+      }
     ]
   },
   "mixins": [


### PR DESCRIPTION
The storage overlay takes the whole screen, so we hide SkyBlock Item List while it's open — that part is on purpose. 

The problem: the item list also saved itself as "off" when the menu closed, so it stayed hidden everywhere else too. This marks the overlay's screens as excluded, so the item list only hides inside the overlay and shows normally everywhere else.