### PR TITLE
fix(ChestProfit): correct dungeon reward prices

### DIFF
--- a/src/main/kotlin/com/github/noamm9/features/impl/dungeon/ChestProfit.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/dungeon/ChestProfit.kt
@@ -236,7 +236,7 @@ object ChestProfit: Feature("Dungeon Chest Profit Calculator") {
 
     private fun getItemValue(stack: ItemStack): Long {
         val itemName = stack.hoverName.formattedText
-        val itemId = stack.skyblockId
+        val itemId = getIdFromName(itemName) ?: stack.skyblockId
         var value = 0L
 
         if (itemId == "ENCHANTED_BOOK") {


### PR DESCRIPTION
Fixes Chest Profit using starred item prices for dungeon rewards while the chest shows the normal item