### PR TITLE
Fix tooltip NPE and GIF repetition parsing

### DIFF
--- a/src/main/java/com/github/noamm9/mixin/MixinAbstractContainerScreen.java
+++ b/src/main/java/com/github/noamm9/mixin/MixinAbstractContainerScreen.java
@@ -88,7 +88,7 @@ public abstract class MixinAbstractContainerScreen extends Screen {
     private void onRenderTooltipMerged(GuiGraphicsExtractor instance, Font font, List<Component> texts, Optional<TooltipComponent> optionalImage, int xo, int yo, @org.jspecify.annotations.Nullable Identifier style, Operation<Void> original, @Local ItemStack item) {
         if (item == null || item.isEmpty() || texts.isEmpty()) original.call(instance, font, texts, optionalImage, xo, yo, style);
         else {
-            ItemTooltip.setSlot(this.hoveredSlot.index);
+            if (this.hoveredSlot != null) ItemTooltip.setSlot(this.hoveredSlot.index);
 
             var event = new ContainerEvent.Render.Tooltip(this, instance, item, xo, yo, new ArrayList<>(texts));
             if (EventBus.post(event)) return;

--- a/src/main/java/com/github/noamm9/utils/GifDecoder.java
+++ b/src/main/java/com/github/noamm9/utils/GifDecoder.java
@@ -124,7 +124,7 @@ public final class GifDecoder {
         // The only app extension widely used is NETSCAPE, it's got 3 data bytes
         if (subBlockSize == 3) {
             // in[i+1] should have value 01, in[i+5] should be block terminator
-            img.repetitions = in[i + 2] & 0xFF | in[i + 3] & 0xFF << 8; // Short
+            img.repetitions = in[i + 2] & 0xFF | (in[i + 3] & 0xFF) << 8; // Short
             return i + 5;
         } // Skip unknown application extensions
         while ((in[i] & 0xFF) != 0) { // While sub-block size != 0


### PR DESCRIPTION
Fixes a crash when rendering tooltips without a hovered slot and corrects operator precedence in GIF metadata parsing.

#### Changes
* **`MixinAbstractContainerScreen`**: Added a null check for `hoveredSlot` before calling `ItemTooltip.setSlot()` to avoid an NPE when rendering tooltips without an active slot target.
* **`GifDecoder`**: Added parentheses around `(in[i + 3] & 0xFF)` in `readAppExt()` so the bitwise shift evaluates after masking, properly parsing the high byte for loop repetitions.