### PR TITLE
FEAT: Dev Cosmetic-Halo.

### DIFF
--- a/src/main/kotlin/com/github/noamm9/features/impl/dev/Cosmetics.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/dev/Cosmetics.kt
@@ -1,15 +1,20 @@
 package com.github.noamm9.features.impl.dev
 
 import com.github.noamm9.NoammAddons
+import com.github.noamm9.NoammAddons.mc
+import com.github.noamm9.event.impl.RenderWorldEvent
 import com.github.noamm9.features.Feature
 import com.github.noamm9.features.impl.dev.text.TextReplacer
 import com.github.noamm9.ui.clickgui.components.impl.ButtonSetting
+import com.github.noamm9.ui.clickgui.components.impl.ColorSetting
 import com.github.noamm9.ui.clickgui.components.impl.ToggleSetting
 import com.github.noamm9.ui.notification.NotificationManager
 import com.github.noamm9.utils.ChatUtils
 import com.github.noamm9.utils.NumbersUtils
 import com.github.noamm9.utils.network.ProfileUtils
 import com.github.noamm9.utils.network.WebUtils
+import com.github.noamm9.utils.render.Render3D.renderBox
+import com.github.noamm9.utils.render.RenderHelper.renderVec
 import com.mojang.authlib.GameProfile
 import com.mojang.blaze3d.vertex.PoseStack
 import kotlinx.coroutines.*
@@ -19,13 +24,16 @@ import net.minecraft.client.player.AbstractClientPlayer
 import net.minecraft.client.renderer.entity.state.AvatarRenderState
 import net.minecraft.world.entity.Avatar
 import net.minecraft.world.phys.Vec3
+import java.awt.Color
 import java.util.*
 import java.util.concurrent.*
 import kotlin.math.absoluteValue
+import kotlin.math.sin
 
 object Cosmetics: Feature(toggled = true) {
     val customNames by ToggleSetting("Show Custom Names", true)
     val customSizes by ToggleSetting("Show Custom Sizes", true)
+    val showHalo by ToggleSetting("Show Halo", true).showIf { hasHaloAccess() }
     val reload by ButtonSetting("Reload Cosmetics") {
         if (System.currentTimeMillis() - lastReload >= 15_000) init()
         else NotificationManager.push("Cosmetics", "Please wait another ${NumbersUtils.formatTime(150_000 - (System.currentTimeMillis() - lastReload))} before reloading again.")
@@ -34,6 +42,21 @@ object Cosmetics: Feature(toggled = true) {
     private var lastReload = System.currentTimeMillis()
     private val profileNames = ConcurrentHashMap<UUID, String>()
     lateinit var cosmeticPeople: Map<UUID, CosmeticData>
+
+    // Ported 1:1 from the 1.8.9 halo.addBox(x, -10, z, 1, 1, 1) calls — pixel-unit (x, z) min corners.
+    private val haloPixels = listOf(
+        -2 to -6, 1 to 5, 0 to 5, -1 to 5, -2 to 5, -2 to 4, -3 to 4, -4 to 4, -4 to 3, -5 to 3,
+        -5 to 2, -5 to 1, -6 to 1, -6 to -2, -6 to -1, 1 to 4, 2 to 4, 3 to 4, 3 to 3, 4 to 3,
+        4 to 2, 4 to 1, 5 to 1, 5 to 0, 5 to -1, 5 to -2, -6 to 0, -5 to -2, -5 to -3, -5 to -4,
+        -4 to -4, -4 to -5, -3 to -5, -2 to -5, 4 to -2, 4 to -3, 4 to -4, 3 to -4, 3 to -5,
+        2 to -5, 1 to -5, 1 to -6, 0 to -6, -1 to -6
+    )
+    private const val PIXEL = 0.0625 // 1/16 block, matches the model's render(0.0625f) scale in 1.8.9
+
+    //test since I cant edit api...
+    private val testHaloPlayers = setOf(
+        UUID.fromString("9806982a-1ecc-42bb-8899-cea654560bc3")
+    )
 
     override fun init() {
         scope.launch(Dispatchers.IO) {
@@ -59,6 +82,34 @@ object Cosmetics: Feature(toggled = true) {
                 ChatUtils.modMessage("&cFailed to load cosmetic people: ${cause.message}")
             }
         }
+
+        register<RenderWorldEvent> {
+            if (! showHalo.value) return@register
+
+            val bobOffset = (sin(System.currentTimeMillis() % 2000L / 2000f * (Math.PI.toFloat() * 2f)) + 1f) / 2f * 0.08f
+
+            val iterator = level.entitiesForRendering().iterator()
+            while (iterator.hasNext()) {
+                val entity = iterator.next()
+                if (entity !is AbstractClientPlayer) continue
+                if (entity == mc.player && mc.options.cameraType.isFirstPerson) continue
+
+                val data = if (::cosmeticPeople.isInitialized) cosmeticPeople[entity.gameProfile.id] else null
+                if (data?.hasHalo != true && entity.gameProfile.id !in testHaloPlayers) continue
+
+                val sizeScale = if (customSizes.value && data?.hasCustomSize == true) data.sizeY.absoluteValue else 1f
+                val baseHeight = (entity.eyeHeight + 0.5f + bobOffset) * sizeScale
+                val center = entity.renderVec.add(0.0, baseHeight.toDouble(), 0.0)
+                val color = Color.decode(data?.haloColor ?: "#FFE650")
+
+                val cubeSize = PIXEL * sizeScale
+                for ((px, pz) in haloPixels) {
+                    val x = center.x + (px + 0.5) * PIXEL * sizeScale
+                    val z = center.z + (pz + 0.5) * PIXEL * sizeScale
+                    event.ctx.renderBox(x, center.y, z, cubeSize, cubeSize, color, outline = false)
+                }
+            }
+        }
     }
 
     @JvmStatic
@@ -67,6 +118,13 @@ object Cosmetics: Feature(toggled = true) {
         if (! customSizes.value) return
         if (avatar !is AbstractClientPlayer) return
         state.setData(GAME_PROFILE_KEY, avatar.gameProfile)
+    }
+
+    @JvmStatic
+    private fun hasHaloAccess(): Boolean {
+        val uuid = mc.player?.uuid ?: return false
+        val data = if (::cosmeticPeople.isInitialized) cosmeticPeople[uuid] else null
+        return data?.hasHalo == true || uuid in testHaloPlayers
     }
 
     @JvmStatic
@@ -93,6 +151,8 @@ object Cosmetics: Feature(toggled = true) {
         val sizeX: Float = 1f,
         val sizeY: Float = 1f,
         val sizeZ: Float = 1f,
+        val hasHalo: Boolean = false,
+        val haloColor: String = "#FFE650",
     ) {
         val hasCustomName: Boolean get() = name.isNotEmpty()
         val hasCustomSize: Boolean get() = sizeX != 1f || sizeY != 1f || sizeZ != 1f


### PR DESCRIPTION
Added 1.8.9 NA Halo cosmetic (since we last spoke about this you said you didnt want a perfect circle and more like 1.8.9).
if you could add integration to the JSON, I want the devs to be able to choose their own colors either in the site or by speaking to you etc...
 the JSON will have:
 "halo": "true",
 "haloColor": "#FFE650"
 I have used AI for this (sorry 😅)

ive kept the testing list: "testHaloPlayers"