### PR TITLE
fix(LoadoutKeybinds): middle click keybind being ignored

### DIFF
--- a/src/main/kotlin/com/github/noamm9/features/impl/general/LoadoutKeybinds.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/general/LoadoutKeybinds.kt
@@ -81,9 +81,9 @@ object LoadoutKeybinds: Feature("Allows you to bind SkyBlock loadout slots to yo
         register<ContainerEvent.MouseClick> {
             if (! inLoadoutMenu) return@register
             if (System.currentTimeMillis() - lastClick < 300) return@register
-            if (event.button.equalsOneOf(0, 1, 2)) return@register
+            if (event.button.equalsOneOf(GLFW.GLFW_MOUSE_BUTTON_LEFT, GLFW.GLFW_MOUSE_BUTTON_RIGHT)) return@register
             val index = if (useHotbarBinds.value) hotbarKeyMap[event.button] ?: return@register
-            else keybinds.withIndex().find { (_, key) -> key.isDown() }?.index ?: return@register
+            else keybinds.indexOfFirst { it.matches(event.button, mouse = true) }.takeUnless { it == - 1 } ?: return@register
             event.isCanceled = true
             handleKeybind(index)
         }


### PR DESCRIPTION
### Description
Fixes middle mouse button loadout keybinds being ignored

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Other (please describe):

### How Has This Been Tested?
I tested it ingame