### PR TITLE
fix: chest profit

### DIFF
--- a/src/main/kotlin/com/github/noamm9/features/impl/dungeon/ChestProfit.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/dungeon/ChestProfit.kt
@@ -240,7 +240,9 @@ object ChestProfit: Feature("Dungeon Chest Profit Calculator") {
             if (mc.hasControlDown()) return@register
             if (! LocationUtils.world.equalsOneOf(WorldType.DungeonHub, WorldType.Catacombs)) return@register
             val chest = DungeonChest.getFromName(event.screen.title.unformattedText) ?: return@register
-            if (chest.profit <= rerollValue.value) return@register
+            if (rerollValue.value == 0) return@register
+            val formatedProfit = rerollValue.value * 1000000L
+            if (chest.profit <= formatedProfit) return@register
             val lastLine = player.containerMenu.getSlot(50).item.lore.last().removeFormatting()
             if (lastLine == "You already rerolled a chest!") return@register
             if (lastLine != "Click to reroll this chest!") return@register

--- a/src/main/kotlin/com/github/noamm9/features/impl/dungeon/ChestProfit.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/dungeon/ChestProfit.kt
@@ -235,14 +235,13 @@ object ChestProfit: Feature("Dungeon Chest Profit Calculator") {
         }
 
         register<ContainerEvent.SlotClick> {
+            if (rerollValue.value == 0) return@register
             if (event.slotId != 50) return@register
             if (event.screen !is ContainerScreen) return@register
             if (mc.hasControlDown()) return@register
             if (! LocationUtils.world.equalsOneOf(WorldType.DungeonHub, WorldType.Catacombs)) return@register
             val chest = DungeonChest.getFromName(event.screen.title.unformattedText) ?: return@register
-            if (rerollValue.value == 0) return@register
-            val formatedProfit = rerollValue.value * 1000000L
-            if (chest.profit <= formatedProfit) return@register
+            if (chest.profit <= rerollValue.value * 1_000_000L) return@register
             val lastLine = player.containerMenu.getSlot(50).item.lore.last().removeFormatting()
             if (lastLine == "You already rerolled a chest!") return@register
             if (lastLine != "Click to reroll this chest!") return@register


### PR DESCRIPTION
bug fix : chest profit

### Description

1. setting rerollValue to 0 didnt return ContainerEvent.SlotClick fix: added if (rerollValue.value == 0) return@register

2. setting rerollValue was not transfered to millions when comparing = setting rerollValue to 5 "M" was actually just 5 fix:
- added formatedProfit = rerollValue.value * 1_000_000L

### Type of change

- [ ] Bug fix

### How Has This Been Tested?

added missing logic that i guess was originally intended !
(i dont have any more than 1 million profit chests but setting it to 0 works)