### PR TITLE
feat(AutoTerminal): allow melody skip-chain to arm from row 1 on colu…

### DIFF
--- a/src/main/kotlin/com/github/noamm9/features/impl/floor7/terminals/AutoTerminal.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/floor7/terminals/AutoTerminal.kt
@@ -70,7 +70,7 @@ object AutoTerminal: Feature("Automatically clicks terminals for you.") {
 
             if (buttonRow == 3) return@register
             if (! melodySkip.value) return@register
-            if (! melodySkipFirstRow.value && buttonRow == 0) return@register
+            if (! melodySkipFirstRow.value && buttonRow == 0 && current != 4) return@register
             if (! (melodySkipMode.value == 1 || (melodySkipMode.value == 0 && (current == 0 || current == 4)))) return@register
 
             val windowId = TerminalListener.lastWindowId


### PR DESCRIPTION
…mn 4

 ### Description                                                                                                                                                                                                                   
  Melody terminal's skip-chain previously never armed off row 1's own hit — `AutoTerminal.kt:73` blocked `buttonRow == 0` unless the "Skip First Row" (red/risky) toggle was on. Now row 1 can arm the chain on its own when it     
  lands on column 4 specifically, without needing that toggle; column 0 (and all other columns) on row 1 still stay blocked by default.                                                                                             
                                                                                                                                                                                                                                    
  ### Type of change                                                                                                                                                                                                                
                                                                                                                                                                                                                                    
  - [ ] Bug fix                                                                                                                                                                                                                     
  - [x] New feature                                                                                                                                                                                                                 
  - [ ] Refactor                                                                                                                                                                                                                    
  - [ ] Performance improvement                                                                                                                                                                                                     
  - [ ] Other (please describe):                                                                                                                                                                                                    
                                                                                                                                                                                                                                    
  ### How Has This Been Tested?                                                                                                                                                                                                     
                                                                                                                                                                                                                                    
  - [x] `./gradlew compileCheatKotlin` / `./gradlew build` — compiles clean, no errors                                                                                                                                              
  - [x] p3sim (row 1 correct landing on column 4, skip mode: Edges)