### PR TITLE
fix(PetMenu): hotbar binds not working with mouse buttons

### DIFF
--- a/src/main/kotlin/com/github/noamm9/features/impl/visual/PetMenu.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/visual/PetMenu.kt
@@ -23,6 +23,7 @@ import com.github.noamm9.utils.render.Render2D.drawCenteredString
 import com.github.noamm9.utils.render.Render2D.drawLine
 import com.github.noamm9.utils.render.Render2D.drawRect
 import com.github.noamm9.utils.render.RenderHelper.width
+import com.mojang.blaze3d.platform.InputConstants
 import gg.essential.universal.UKeyboard
 import net.minecraft.client.gui.GuiGraphicsExtractor
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen
@@ -221,7 +222,10 @@ object PetMenu: Feature("Replaces the Pets inventory with a custom pet wheel."),
             val keyName = run {
                 if (useHotbarBinds.value) {
                     val keybind = mc.options.keyHotbarSlots.getOrNull(index) as? IKeyMapping
-                    keybind?.key?.displayName?.string?.uppercase()
+                    keybind?.key?.let { key ->
+                        val name = key.displayName.string.uppercase()
+                        if (key.type == InputConstants.Type.MOUSE) name.replace("BUTTON ", "M") else name
+                    }
                 }
                 else keybinds.getOrNull(index)?.displayName()
             } ?: return
@@ -261,9 +265,9 @@ object PetMenu: Feature("Replaces the Pets inventory with a custom pet wheel."),
 
     private fun handleKeybind(screen: AbstractContainerScreen<*>, code: Int, mouse: Boolean): Boolean {
         val index = if (useHotbarBinds.value) {
-            if (mouse) return false
+            val type = if (mouse) InputConstants.Type.MOUSE else InputConstants.Type.KEYSYM
             mc.options.keyHotbarSlots.take(PETS_PER_WHEEL).withIndex().find {
-                (it.value as IKeyMapping).key.value == code
+                (it.value as IKeyMapping).key.let { key -> key.type == type && key.value == code }
             }?.index ?: - 1
         }
         else keybinds.indexOfFirst { it.matches(code, mouse) }


### PR DESCRIPTION
### Description
This fixes an issue where mouse buttons could not be used while `Use Hotbar Binds` was enabled. It also renames mouse button labels from `BUTTON 5` to `M5` so they fit properly within the keybind labels. Linked issue: https://discord.com/channels/1281979747605418024/1541085298761662557

### Type of change

- [x] Bug fix

### How Has This Been Tested?
Tested ingame