### PR TITLE
add button and lever hitbox size setting

### DIFF
--- a/src/main/java/com/github/noamm9/mixin/MixinLeverBlock.java
+++ b/src/main/java/com/github/noamm9/mixin/MixinLeverBlock.java
@@ -20,7 +20,7 @@ public class MixinLeverBlock {
     @Inject(method = "getShape", at = @At("HEAD"), cancellable = true)
     private void modifyShape(BlockState state, BlockGetter level, BlockPos pos, CollisionContext context, CallbackInfoReturnable<VoxelShape> cir) {
         if (Secrets.isValidLever(pos)) {
-            cir.setReturnValue(Shapes.block());
+            cir.setReturnValue(Secrets.getLeverShape(state));
         }
     }
 }

--- a/src/main/kotlin/com/github/noamm9/features/impl/dungeon/Secrets.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/dungeon/Secrets.kt
@@ -23,18 +23,17 @@ import com.github.noamm9.utils.render.Render2D.drawString
 import com.github.noamm9.utils.render.world.Render3D.renderBlock
 import com.github.noamm9.utils.render.RenderHelper.width
 import net.minecraft.core.BlockPos
-import net.minecraft.core.Direction
 import net.minecraft.network.protocol.game.ClientboundOpenScreenPacket
 import net.minecraft.network.protocol.game.ServerboundContainerClosePacket
 import net.minecraft.sounds.SoundEvents
 import net.minecraft.world.inventory.MenuType
+import net.minecraft.world.level.block.Block
 import net.minecraft.world.level.block.ButtonBlock
 import net.minecraft.world.level.block.FaceAttachedHorizontalDirectionalBlock
 import net.minecraft.world.level.block.state.BlockState
-import net.minecraft.world.level.block.state.properties.AttachFace
 import net.minecraft.world.phys.shapes.Shapes
 import net.minecraft.world.phys.shapes.VoxelShape
-import java.util.concurrent.*
+import java.util.concurrent.ConcurrentHashMap
 
 object Secrets: Feature() {
     private val hudDisplay by ToggleSetting("Secret HUD", true).withDescription("Displays the current room's secrets on screen.").section("HUD")
@@ -42,7 +41,8 @@ object Secrets: Feature() {
     //#if CHEAT
     private val closeChest by ToggleSetting("Close Chest").section("Auto").withDescription("Automatically closes the secret chest for you.")
     private val lever by ToggleSetting("Lever").withDescription("Full block Lever hitbox.").section("Secret Hitboxes")
-    @JvmStatic val button by ToggleSetting("Button").withDescription("Full block button hitbox.")
+    @JvmStatic val button by ToggleSetting("Button").withDescription("Expand button hitbox.")
+    val buttonSize by SliderSetting("Button Hitbox Size", 1.0, 6.0 / 16.0, 1.0, 0.01).showIf { button.value }
     @JvmStatic val skull by ToggleSetting("Skulls").withDescription("Full block Skull hitbox.")
     @JvmStatic val mushroom by ToggleSetting("Mushroom").withDescription("Full block Mushroom hitbox.")
     //#endif
@@ -129,20 +129,8 @@ object Secrets: Feature() {
         val face = state.getValue(FaceAttachedHorizontalDirectionalBlock.FACE)
         val direction = state.getValue(FaceAttachedHorizontalDirectionalBlock.FACING)
         val powered = state.getValue(ButtonBlock.POWERED)
-
-        val f2 = (if (powered) 1 else 2) / 16.0
-        return when (face) {
-            AttachFace.CEILING -> Shapes.box(0.0, 1.0 - f2, 0.0, 1.0, 1.0, 1.0)
-            AttachFace.FLOOR -> Shapes.box(0.0, 0.0, 0.0, 1.0, 0.0 + f2, 1.0)
-            else -> when (direction) {
-                Direction.EAST -> Shapes.box(0.0, 0.0, 0.0, f2, 1.0, 1.0)
-                Direction.WEST -> Shapes.box(1.0 - f2, 0.0, 0.0, 1.0, 1.0, 1.0)
-                Direction.SOUTH -> Shapes.box(0.0, 0.0, 0.0, 1.0, 1.0, f2)
-                Direction.NORTH -> Shapes.box(0.0, 0.0, 1.0 - f2, 1.0, 1.0, 1.0)
-                Direction.UP -> Shapes.box(0.0, 0.0, 0.0, 1.0, 0.0 + f2, 1.0)
-                Direction.DOWN -> Shapes.box(0.0, 1.0 - f2, 0.0, 1.0, 1.0, 1.0)
-            }
-        }
+        val base = Block.boxZ(buttonSize.value * 16.0, 16.0 - if (powered) 1 else 2, 16.0)
+        return Shapes.rotateAttachFace(base)[face]?.get(direction)!!
     }
 
     private val blackListedLevers = listOf(

--- a/src/main/kotlin/com/github/noamm9/features/impl/dungeon/Secrets.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/dungeon/Secrets.kt
@@ -33,7 +33,7 @@ import net.minecraft.world.level.block.FaceAttachedHorizontalDirectionalBlock
 import net.minecraft.world.level.block.state.BlockState
 import net.minecraft.world.phys.shapes.Shapes
 import net.minecraft.world.phys.shapes.VoxelShape
-import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.*
 
 object Secrets: Feature() {
     private val hudDisplay by ToggleSetting("Secret HUD", true).withDescription("Displays the current room's secrets on screen.").section("HUD")
@@ -41,9 +41,9 @@ object Secrets: Feature() {
     //#if CHEAT
     private val closeChest by ToggleSetting("Close Chest").section("Auto").withDescription("Automatically closes the secret chest for you.")
     private val lever by ToggleSetting("Lever").withDescription("Expand block Lever hitbox.").section("Secret Hitboxes")
-    val leverSize by SliderSetting("Lever Hitbox Size", 1.0, 8.0 / 16.0, 1.0, 0.01).showIf { button.value }
+    private val leverSize by SliderSetting("Lever Hitbox Size", 1.0, 8.0 / 16.0, 1.0, 0.01).showIf { button.value }
     @JvmStatic val button by ToggleSetting("Button").withDescription("Expand button hitbox.")
-    val buttonSize by SliderSetting("Button Hitbox Size", 1.0, 6.0 / 16.0, 1.0, 0.01).showIf { button.value }
+    private val buttonSize by SliderSetting("Button Hitbox Size", 1.0, 6.0 / 16.0, 1.0, 0.01).showIf { button.value }
     @JvmStatic val skull by ToggleSetting("Skulls").withDescription("Full block Skull hitbox.")
     @JvmStatic val mushroom by ToggleSetting("Mushroom").withDescription("Full block Mushroom hitbox.")
     //#endif
@@ -131,7 +131,7 @@ object Secrets: Feature() {
         val facing = state.getValue(FaceAttachedHorizontalDirectionalBlock.FACING)
         val powered = state.getValue(ButtonBlock.POWERED)
         val base = Block.boxZ(buttonSize.value * 16.0, 16.0 - if (powered) 1 else 2, 16.0)
-        return Shapes.rotateAttachFace(base)[face]?.get(facing)!!
+        return Shapes.rotateAttachFace(base)[face]?.get(facing) !!
     }
 
     @JvmStatic
@@ -139,14 +139,16 @@ object Secrets: Feature() {
         val face = state.getValue(FaceAttachedHorizontalDirectionalBlock.FACE)
         val facing = state.getValue(FaceAttachedHorizontalDirectionalBlock.FACING)
         val base = Block.boxZ(leverSize.value * 16.0, leverSize.value * 16.0, 16.0 - leverSize.value * 16.0, 16.0)
-        return Shapes.rotateAttachFace(base)[face]?.get(facing)!!
+        return Shapes.rotateAttachFace(base)[face]?.get(facing) !!
     }
 
     private val blackListedLevers = listOf(
-        BlockPos(61, 136, 142), BlockPos(60, 136, 142), BlockPos(59, 136, 142),
-        BlockPos(62, 135, 142), BlockPos(61, 135, 142), BlockPos(59, 135, 142),
-        BlockPos(58, 135, 142), BlockPos(62, 134, 142), BlockPos(61, 134, 142),
-        BlockPos(59, 134, 142), BlockPos(58, 134, 142), BlockPos(61, 133, 142),
+        BlockPos(61, 136, 142), BlockPos(60, 136, 142),
+        BlockPos(59, 136, 142), BlockPos(62, 135, 142),
+        BlockPos(61, 135, 142), BlockPos(59, 135, 142),
+        BlockPos(58, 135, 142), BlockPos(62, 134, 142),
+        BlockPos(61, 134, 142), BlockPos(59, 134, 142),
+        BlockPos(58, 134, 142), BlockPos(61, 133, 142),
         BlockPos(60, 133, 142), BlockPos(59, 133, 142)
     )
 

--- a/src/main/kotlin/com/github/noamm9/features/impl/dungeon/Secrets.kt
+++ b/src/main/kotlin/com/github/noamm9/features/impl/dungeon/Secrets.kt
@@ -20,8 +20,8 @@ import com.github.noamm9.utils.dungeons.enums.SecretType
 import com.github.noamm9.utils.equalsOneOf
 import com.github.noamm9.utils.location.LocationUtils
 import com.github.noamm9.utils.render.Render2D.drawString
-import com.github.noamm9.utils.render.world.Render3D.renderBlock
 import com.github.noamm9.utils.render.RenderHelper.width
+import com.github.noamm9.utils.render.world.Render3D.renderBlock
 import net.minecraft.core.BlockPos
 import net.minecraft.network.protocol.game.ClientboundOpenScreenPacket
 import net.minecraft.network.protocol.game.ServerboundContainerClosePacket
@@ -40,7 +40,8 @@ object Secrets: Feature() {
 
     //#if CHEAT
     private val closeChest by ToggleSetting("Close Chest").section("Auto").withDescription("Automatically closes the secret chest for you.")
-    private val lever by ToggleSetting("Lever").withDescription("Full block Lever hitbox.").section("Secret Hitboxes")
+    private val lever by ToggleSetting("Lever").withDescription("Expand block Lever hitbox.").section("Secret Hitboxes")
+    val leverSize by SliderSetting("Lever Hitbox Size", 1.0, 8.0 / 16.0, 1.0, 0.01).showIf { button.value }
     @JvmStatic val button by ToggleSetting("Button").withDescription("Expand button hitbox.")
     val buttonSize by SliderSetting("Button Hitbox Size", 1.0, 6.0 / 16.0, 1.0, 0.01).showIf { button.value }
     @JvmStatic val skull by ToggleSetting("Skulls").withDescription("Full block Skull hitbox.")
@@ -127,10 +128,18 @@ object Secrets: Feature() {
     @JvmStatic
     fun getButtonShape(state: BlockState): VoxelShape {
         val face = state.getValue(FaceAttachedHorizontalDirectionalBlock.FACE)
-        val direction = state.getValue(FaceAttachedHorizontalDirectionalBlock.FACING)
+        val facing = state.getValue(FaceAttachedHorizontalDirectionalBlock.FACING)
         val powered = state.getValue(ButtonBlock.POWERED)
         val base = Block.boxZ(buttonSize.value * 16.0, 16.0 - if (powered) 1 else 2, 16.0)
-        return Shapes.rotateAttachFace(base)[face]?.get(direction)!!
+        return Shapes.rotateAttachFace(base)[face]?.get(facing)!!
+    }
+
+    @JvmStatic
+    fun getLeverShape(state: BlockState): VoxelShape {
+        val face = state.getValue(FaceAttachedHorizontalDirectionalBlock.FACE)
+        val facing = state.getValue(FaceAttachedHorizontalDirectionalBlock.FACING)
+        val base = Block.boxZ(leverSize.value * 16.0, leverSize.value * 16.0, 16.0 - leverSize.value * 16.0, 16.0)
+        return Shapes.rotateAttachFace(base)[face]?.get(facing)!!
     }
 
     private val blackListedLevers = listOf(


### PR DESCRIPTION
### Description
Add an option to configure the size of the lever and button hitboxes

### Type of change
- [] Other: Setting for an existing feature

### How Has This Been Tested?
Tested in-game on all allowed block placements, orientations and slider positions